### PR TITLE
Match variable & conn ordering with defaults

### DIFF
--- a/astronomer-starship/starship/services/local_client.py
+++ b/astronomer-starship/starship/services/local_client.py
@@ -14,14 +14,14 @@ class LocalAirflowClient:
     def get_connections(self, session: Session):
         from airflow.models import Connection
 
-        connections = session.query(Connection).all()
+        connections = session.query(Connection).order_by(Connection.conn_id).all()
         return connections
 
     @provide_session
     def get_variables(self, session: Session):
         from airflow.models import Variable
 
-        vars = session.query(Variable).all()
+        vars = session.query(Variable).order_by(Variable.key).all()
         return vars
 
     def get_dags(self):


### PR DESCRIPTION
In Airflow's list views, [connections (`/connection/list/`) are ordered by `conn_id`](https://github.com/apache/airflow/blob/65bfea2a20830baa10d2e1e8328c07a7a11bbb0c/airflow/www/views.py#L4182) and [variables (`/variable/list/`) are ordered by `key`](https://github.com/apache/airflow/blob/65bfea2a20830baa10d2e1e8328c07a7a11bbb0c/airflow/www/views.py#L4613). When comparing those views with the list that Starship presents the ordering does not match up, making it a bit more difficult to compare them.

The proposed change here adjusts the ordering to match the ordering on the connection and variable list views to make it easier to compare the two pages.