### PR TITLE
Add loading placeholders

### DIFF
--- a/astronomer-starship/starship/main.py
+++ b/astronomer-starship/starship/main.py
@@ -36,8 +36,8 @@ class AstroMigration(AppBuilderBaseView):
 
     def __init__(self):
         super().__init__()
-        self.local_client = LocalAirflowClient()
-        self.astro_client = AstroClient()
+        self.local_client: LocalAirflowClient = LocalAirflowClient()
+        self.astro_client: AstroClient = AstroClient()
 
     def get_astro_username(self, token):
         if not token:

--- a/astronomer-starship/starship/templates/starship/components/tabs.html
+++ b/astronomer-starship/starship/templates/starship/components/tabs.html
@@ -1,15 +1,23 @@
 <div class="container">
-  <ul class="nav nav-tabs">
-  <li class="nav-item {{ 'active' if data.component == 'connections' }}"><a class="nav-link" hx-get="{{ url_for('AstroMigration.tabs_conns') }}">Connections</a></li>
-  <li class="nav-item {{ 'active' if data.component == 'variables' }}"><a class="nav-link" hx-get="{{ url_for('AstroMigration.tabs_vars') }}">Variables</a></li>
-  <li class="nav-item {{ 'active' if data.component == 'env' }}"><a class="nav-link" hx-get="{{ url_for('AstroMigration.tabs_env') }}">Environment Variables</a></li>
-  <li class="nav-item {{ 'active' if data.component == 'dags' }}"><a class="nav-link" hx-get="{{ url_for('AstroMigration.tabs_dags') }}">DAGs cutover</a></li>
-</ul>
+    <ul class="nav nav-tabs">
+        <li class="nav-item {{ 'active' if data.component == 'connections' }}">
+            <a class="nav-link" hx-get="{{ url_for('AstroMigration.tabs_conns') }}">Connections</a>
+        </li>
+        <li class="nav-item {{ 'active' if data.component == 'variables' }}">
+            <a class="nav-link" hx-get="{{ url_for('AstroMigration.tabs_vars') }}">Variables</a>
+        </li>
+        <li class="nav-item {{ 'active' if data.component == 'env' }}">
+            <a class="nav-link" hx-get="{{ url_for('AstroMigration.tabs_env') }}">Environment Variables</a>
+        </li>
+        <li class="nav-item {{ 'active' if data.component == 'dags' }}">
+            <a class="nav-link" hx-get="{{ url_for('AstroMigration.tabs_dags') }}">DAGs cutover</a>
+        </li>
+    </ul>
 </div>
 <div class="tab-content">
-  <div class="container">
-  {% block body %}
-  <!-- Tab content goes here -->
-  {% endblock %}
-  </div>
+    <div class="container">
+        {% block body %}
+        <!-- Tab content goes here -->
+        {% endblock %}
+    </div>
 </div>

--- a/astronomer-starship/starship/templates/starship/components/tabs.html
+++ b/astronomer-starship/starship/templates/starship/components/tabs.html
@@ -14,7 +14,7 @@
         </li>
     </ul>
 </div>
-<div class="tab-content">
+<div class="tab-content" id="tabs-content">
     <div class="container">
         {% block body %}
         <!-- Tab content goes here -->

--- a/astronomer-starship/starship/templates/starship/components/tabs_loading.html
+++ b/astronomer-starship/starship/templates/starship/components/tabs_loading.html
@@ -1,0 +1,52 @@
+<div class="container">
+    <ul class="nav nav-tabs">
+        <li class="nav-item" class="disabled">
+            <a class="nav-link">Connections</a>
+        </li>
+        <li class="nav-item" class="disabled">
+            <a class="nav-link">Variables</a>
+        </li>
+        <li class="nav-item" class="disabled">
+            <a class="nav-link">Environment Variables</a></li>
+        <li class="nav-item" class="disabled">
+            <a class="nav-link">DAGs cutover</a>
+        </li>
+    </ul>
+</div>
+<div class="tab-content">
+    <div class="container">
+        <form>
+            <table class="table table-striped table-bordered table-hover">
+                <thead>
+                <tr>
+                    <th scope="col">Type</th>
+                    <th scope="col">Id</th>
+                    <th scope="col">Host</th>
+                    <th scope="col">Login</th>
+                    <th scope="col">Schema</th>
+                    <th scope="col">Port</th>
+                    <th scope="col">Extra</th>
+                    <th>
+                    </th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>Loading....</td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td style="font-family: monospace; overflow: hidden; text-overflow: ellipsis;"></td>
+                    <td class="text-right">
+                        <div>
+                            <button class="btn btn-default disabled">Migrate</button>
+                        </div>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </form
+    </div>
+</div>

--- a/astronomer-starship/starship/templates/starship/components/tabs_loading.html
+++ b/astronomer-starship/starship/templates/starship/components/tabs_loading.html
@@ -13,8 +13,9 @@
         </li>
     </ul>
 </div>
-<div class="tab-content">
+<div class="tab-content" id="tabs-content">
     <div class="container">
+        {% block body %}
         <form>
             <table class="table table-striped table-bordered table-hover">
                 <thead>
@@ -47,6 +48,7 @@
                 </tr>
                 </tbody>
             </table>
-        </form
+        </form>
+        {% endblock %}
     </div>
 </div>

--- a/astronomer-starship/starship/templates/starship/components/target_deployment_select_loading.html
+++ b/astronomer-starship/starship/templates/starship/components/target_deployment_select_loading.html
@@ -1,0 +1,28 @@
+<div class="container" style="padding-top: 15px;">
+    <form method="post">
+        <div class="form-group">
+            <div class="row">
+                <div class="col-lg-3">
+                    <label for="currentUser" class="form-label">Current user</label>
+                </div>
+                <div class="col-lg-6">
+                    <label id="currentUser" class="form-label"><span>Loading.......</span>
+                        (<a>Logout</a>)</label>
+                </div>
+            </div>
+            <div class="row" style="padding-top: 15px;">
+                <div class="col-lg-3">
+                    <label for="selectedAstroDeployment" class="form-label">Target Deployment</label>
+                </div>
+                <div class="col-lg-6">
+                    <select id="selectedAstroDeployment" class="form-control" name="selectedAstroDeployment">
+                        <option value="" selected disabled>Select deployment</option>
+                    </select>
+                </div>
+                <div class="col-lg-3">
+                    <button type="submit" disabled class="btn btn-primary mb3-l">Select</button>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>

--- a/astronomer-starship/starship/templates/starship/migration.html
+++ b/astronomer-starship/starship/templates/starship/migration.html
@@ -1,15 +1,23 @@
 <div id="astro-token-entry"
      hx-get="{{ url_for('AstroMigration.modal_token_entry') }}"
      hx-trigger="load delay:100ms"
-     hx-target="#astro-token-entry" hx-swap="outerHTML">
+     hx-swap="outerHTML">
 </div>
 <div id="astro-deployment-selector"
+     hx-indicator="#astro-deployment-selector-loading"
      hx-get="{{ url_for('AstroMigration.deployment_selector') }}"
      hx-trigger="load delay:100ms"
-     hx-target="#astro-deployment-selector" hx-swap="innerHTML">
+     hx-swap="innerHTML">
+    <div id="astro-deployment-selector-loading" class="htmx-indicator">
+        {% include 'starship/components/target_deployment_select_loading.html' %}
+    </div>
 </div>
 <div id="tabs"
+     hx-indicator="#tabs-loading"
      hx-get="{{ url_for('AstroMigration.tabs_conns') }}"
      hx-trigger="load delay:100ms"
-     hx-target="#tabs" hx-swap="innerHTML">
+     hx-swap="innerHTML">
+    <div id="tabs-loading" class="htmx-indicator">
+        {% include 'starship/components/tabs_loading.html' %}
+    </div>
 </div>

--- a/astronomer-starship/starship/templates/starship/migration.html
+++ b/astronomer-starship/starship/templates/starship/migration.html
@@ -1,12 +1,14 @@
 <div id="astro-token-entry"
      hx-get="{{ url_for('AstroMigration.modal_token_entry') }}"
      hx-trigger="load delay:100ms"
+     hx-target="#astro-token-entry"
      hx-swap="outerHTML">
 </div>
 <div id="astro-deployment-selector"
      hx-indicator="#astro-deployment-selector-loading"
      hx-get="{{ url_for('AstroMigration.deployment_selector') }}"
      hx-trigger="load delay:100ms"
+     hx-target="#astro-deployment-selector"
      hx-swap="innerHTML">
     <div id="astro-deployment-selector-loading" class="htmx-indicator">
         {% include 'starship/components/target_deployment_select_loading.html' %}
@@ -16,6 +18,7 @@
      hx-indicator="#tabs-loading"
      hx-get="{{ url_for('AstroMigration.tabs_conns') }}"
      hx-trigger="load delay:100ms"
+     hx-target="#tabs"
      hx-swap="innerHTML">
     <div id="tabs-loading" class="htmx-indicator">
         {% include 'starship/components/tabs_loading.html' %}


### PR DESCRIPTION
the whole content of the page shifting when things load in was a bit jarring - added some placeholders so now only some small text changes and buttons become active.
<img width="1578" alt="image" src="https://user-images.githubusercontent.com/80706212/226771619-baeddb98-77b6-49ab-8b96-5c5976a82f19.png">


