### PR TITLE
Fix issues with DAG History Migration

### DIFF
--- a/astronomer_starship/starship/main.py
+++ b/astronomer_starship/starship/main.py
@@ -1,5 +1,4 @@
 import os
-import logging
 from typing import Optional
 import jwt
 from airflow.plugins_manager import AirflowPlugin
@@ -71,13 +70,9 @@ class Starship(AppBuilderBaseView):
     @expose("/dag_history/receive", methods=["GET", "POST"])
     @csrf.exempt
     def receive_dag_history(self):
-        data = request.json
-        try:
-            local_airflow_client.receive_dag(data=data)
-            return Response("OK", 200)
-        except Exception as e:
-            logging.exception(e)
-            return Response(str(e), 400)
+        data = request.get_json(force=True)
+        local_airflow_client.receive_dag(data=data)
+        return Response("OK", 200)
 
     @expose("/modal/token")
     def modal_token_entry(self):

--- a/astronomer_starship/starship/services/local_airflow_client.py
+++ b/astronomer_starship/starship/services/local_airflow_client.py
@@ -99,7 +99,7 @@ def receive_dag(session: Session, data: list = None):
             table = Table(table_name, metadata_obj, autoload_with=engine)
 
         with engine.connect() as connection:
-            connection.execute(insert(table).on_conflict_do_nothing(), *data_list)
+            connection.execute(insert(table).on_conflict_do_nothing(), data_list)
             connection.commit()
 
 


### PR DESCRIPTION
- `application/json` isn't being registered if it's sent, and `.json` required that to parse. `get_json(force=True)` fixes that
- SQLAlchemy 2 `Connection.execute()` takes a list, rather than `*args`