### PR TITLE
DAG History Migration - Compatability for sqlalchemy 1.4 and 2.0

### DIFF
--- a/astronomer_starship/starship/services/local_airflow_client.py
+++ b/astronomer_starship/starship/services/local_airflow_client.py
@@ -98,9 +98,8 @@ def receive_dag(session: Session, data: list = None):
         except NoSuchTableError:
             table = Table(table_name, metadata_obj, autoload_with=engine)
 
-        with engine.connect() as connection:
-            connection.execute(insert(table).on_conflict_do_nothing(), data_list)
-            connection.commit()
+        with engine.begin() as txn:
+            txn.execute(insert(table).on_conflict_do_nothing(), data_list)
 
 
 @provide_session


### PR DESCRIPTION
- use .execute that should work for sqlalchemy 1.4 and 2.0