### PR TITLE
Getting DAGs Uses SerializedDAG instead of DagBag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Use https://github.com/nektos/act to run and test CICD changes locally.
     RUN pip install --upgrade pip && pip install ./starship
     USER astro
     ```
-5. Build with your symlink starship `tar -czh . | docker build -t local -`
+5. Build with your symlink starship `tar -czh . | DOCKER_BUILDKIT=1 docker build -t local -`
 6. Start (or restart) the astro project `astro dev <re>start -i local`
 
 # Alternatively

--- a/astronomer_starship/starship/services/local_airflow_client.py
+++ b/astronomer_starship/starship/services/local_airflow_client.py
@@ -7,6 +7,8 @@ from sqlalchemy.dialects.postgresql import insert
 
 from airflow import DAG
 from airflow.models import DagModel, DagRun
+from airflow.models.serialized_dag import SerializedDagModel
+from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.utils.session import provide_session
 from cachetools.func import ttl_cache
 from sqlalchemy import MetaData, Table
@@ -14,7 +16,6 @@ from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm import Session
 from airflow.models import Connection
 from airflow.models import Pool
-from airflow.models import DagBag
 from airflow.models import Variable
 
 
@@ -45,8 +46,8 @@ def get_variable(variable: str):
 
 
 @ttl_cache(ttl=60)
-def get_dags():
-    dags = DagBag().dags
+def get_dags() -> dict[str, SerializedDAG]:
+    dags = SerializedDagModel.read_all_dags()
     return dags
 
 


### PR DESCRIPTION
I noticed a case on Astro where the webserver didn't have any DAGs in the container's `dags` directory.  Airflow 2.0 introduced Serialized DAGs which keep the webserver stateless and offload the parsing process to the scheduler.  This also keeps the webserver more lightweight.

When we get DAGs for the DAGs Cutover view, it used the DagBag which pulls DAGs locally, however when there are no DAGs in the webserver, this returns no results.

This PR changes `get_dags` in the local client to use `SerializedDagModel.read_all_dags()` in order to pick up DAGs that are parsed and serialized.

I also changed `CONTRIBUTING.md` to use the `DOCKER_BUILDKIT=1` argument, which I needed when building locally.