### PR TITLE
Add DESC sort to start_date for DAGRun History

### DIFF
--- a/astronomer_starship/starship/services/local_airflow_client.py
+++ b/astronomer_starship/starship/services/local_airflow_client.py
@@ -105,7 +105,7 @@ def receive_dag(session: Session, data: list = None):
 
 @provide_session
 def get_dag_runs_and_task_instances(
-    session: Session, dag_id: str
+    session: Session, dag_id: str, limit: int = 5
 ) -> List[Dict[str, Any]]:
     def _as_json_with_table(_row):
         _r = {col.name: getattr(_row, col.name) for col in _row.__table__.columns}
@@ -119,7 +119,7 @@ def get_dag_runs_and_task_instances(
         session.query(DagRun)
         .filter(DagRun.dag_id == dag_id)
         .order_by(desc(DagRun.start_date))
-        .limit(5)
+        .limit(limit)
         .all()
     )
     logging.debug(

--- a/astronomer_starship/starship/services/local_airflow_client.py
+++ b/astronomer_starship/starship/services/local_airflow_client.py
@@ -4,6 +4,7 @@ import pickle
 from typing import List, Dict, Any
 
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy import desc
 
 from airflow import DAG
 from airflow.models import DagModel, DagRun
@@ -117,7 +118,7 @@ def get_dag_runs_and_task_instances(
     dag_runs = (
         session.query(DagRun)
         .filter(DagRun.dag_id == dag_id)
-        .order_by(DagRun.start_date)
+        .order_by(desc(DagRun.start_date))
         .limit(5)
         .all()
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astronomer-starship"
-version = "1.2.0"
+version = "1.2.1"
 description = "Migrations to Astro"
 authors = ["CSE Team <cse@astronomer.io>"]
 readme = "README.rst"


### PR DESCRIPTION
Observed Starship pushing older DAGRun history, potential hypothesis is that results were unsorted. 
This wouldn't have shown up with a smaller amount of history so may have slipped through testing

fixes #69 