### PR TITLE
fix: don't ignore Airflow 2.9 fields in Airflow 2.10

### DIFF
--- a/astronomer_starship/compat/starship_compatability.py
+++ b/astronomer_starship/compat/starship_compatability.py
@@ -1166,13 +1166,13 @@ class StarshipAirflow29(StarshipAirflow28):
         return attrs
 
 
-class StarshipAirflow210(StarshipAirflow28):
+class StarshipAirflow210(StarshipAirflow29):
     """
     - _try_number to try_number in task_instance
     - executor in task_instance
     """
 
-    # TODO: Identify any other compat issues that exist between 2.8-2.10
+    # TODO: Identify any other compat issues that exist between 2.9-2.10
 
     def task_instance_attrs(self):
         attrs = super().task_instance_attrs()


### PR DESCRIPTION
This resolves the issue that the fields `rendered_map_index` and `task_display_name` - introduced in 2.9 - were not available in 2.10. This is due to the fact that `StarshipAirflow210` inherited from `StarshipAirflow28` instead of `StarshipAirflow29`.

For comparison the result of `GET /api/starship/task_instances?dag_id=example_dag`:

**2.9**
```json
{
  "dag_run_count": 1,
  "task_instances": [
    {
      "custom_operator_name": null,
      "dag_id": "example_dag",
      "duration": 0.080345,
      "end_date": "2025-06-28 04:13:28.466291+00:00",
      "executor_config": null,
      "external_executor_id": null,
      "hostname": "ff69f8f2504e",
      "job_id": 7,
      "map_index": 0,
      "max_tries": 0,
      "operator": "_PythonDecoratedOperator",
      "pid": 202,
      "pool": "default_pool",
      "pool_slots": 1,
      "priority_weight": 1,
      "queue": "default",
      "queued_by_job_id": 1,
      "queued_dttm": "2025-06-28 04:13:28.287295+00:00",
      "rendered_map_index": "Alice",
      "run_id": "scheduled__2025-06-28T03:00:00+00:00",
      "start_date": "2025-06-28 04:13:28.385946+00:00",
      "state": "success",
      "task_display_name": "example_task",
      "task_id": "example_task",
      "trigger_id": null,
      "trigger_timeout": null,
      "try_number": 1,
      "unixname": "astro"
    }
  ]
}
```

**2.10**
```json
{
  "dag_run_count": 1,
  "task_instances": [
    {
      "custom_operator_name": null,
      "dag_id": "example_dag",
      "duration": 0.105657,
      "end_date": "2025-06-28 04:23:11.839398+00:00",
      "executor": null,
      "executor_config": null,
      "external_executor_id": null,
      "hostname": "a397db3e02d9",
      "job_id": 10,
      "map_index": 0,
      "max_tries": 0,
      "operator": "_PythonDecoratedOperator",
      "pid": 178,
      "pool": "default_pool",
      "pool_slots": 1,
      "priority_weight": 1,
      "queue": "default",
      "queued_by_job_id": 9,
      "queued_dttm": "2025-06-28 04:23:11.518938+00:00",
      "run_id": "scheduled__2025-06-28T03:00:00+00:00",
      "start_date": "2025-06-28 04:23:11.733741+00:00",
      "state": "success",
      "task_id": "example_task",
      "trigger_id": null,
      "trigger_timeout": null,
      "try_number": 1,
      "unixname": "astro"
    }
  ]
}
```

**2.10 fixed**
```json
{
  "dag_run_count": 1,
  "task_instances": [
    {
      "custom_operator_name": null,
      "dag_id": "example_dag",
      "duration": 0.105657,
      "end_date": "2025-06-28 04:23:11.839398+00:00",
      "executor": null,
      "executor_config": null,
      "external_executor_id": null,
      "hostname": "a397db3e02d9",
      "job_id": 10,
      "map_index": 0,
      "max_tries": 0,
      "operator": "_PythonDecoratedOperator",
      "pid": 178,
      "pool": "default_pool",
      "pool_slots": 1,
      "priority_weight": 1,
      "queue": "default",
      "queued_by_job_id": 9,
      "queued_dttm": "2025-06-28 04:23:11.518938+00:00",
      "rendered_map_index": "Alice",
      "run_id": "scheduled__2025-06-28T03:00:00+00:00",
      "start_date": "2025-06-28 04:23:11.733741+00:00",
      "state": "success",
      "task_display_name": "example_task",
      "task_id": "example_task",
      "trigger_id": null,
      "trigger_timeout": null,
      "try_number": 1,
      "unixname": "astro"
    }
  ]
}
```

As well an example of a mapped task with named mapping of a DAG migrated with starship on 2.10 before

<img width="769" alt="example 2 10" src="https://github.com/user-attachments/assets/e2e91dc3-a528-43c5-9815-bb83bed37967" />

and after the fix:

<img width="742" alt="example 2 10 fixed" src="https://github.com/user-attachments/assets/c4f13462-f691-4342-b3e7-4e120c2ab0aa" />


