### PR TITLE
feat: add support for Airflow 2.11

### DIFF
--- a/astronomer_starship/__init__.py
+++ b/astronomer_starship/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.4"
+__version__ = "2.3.0"
 
 
 def get_provider_info():

--- a/astronomer_starship/compat/starship_compatability.py
+++ b/astronomer_starship/compat/starship_compatability.py
@@ -1190,6 +1190,13 @@ class StarshipAirflow210(StarshipAirflow29):
         return attrs
 
 
+class StarshipAirflow211(StarshipAirflow210):
+    """
+    There have been no changes to the DB in Airflow 2.11.
+    https://github.com/apache/airflow/tree/2.11.0/airflow/migrations/versions
+    """
+
+
 class StarshipCompatabilityLayer:
     """StarshipCompatabilityLayer is a factory class that returns the correct StarshipAirflow class for a version
 
@@ -1206,6 +1213,7 @@ class StarshipCompatabilityLayer:
     - 2.8 https://github.com/apache/airflow/tree/2.8.3/airflow/models
     - 2.9 https://github.com/apache/airflow/tree/2.9.3/airflow/models
     - 2.10 https://github.com/apache/airflow/tree/2.10.3/airflow/models
+    - 2.11 https://github.com/apache/airflow/tree/2.11.0/airflow/models
 
     >>> isinstance(StarshipCompatabilityLayer("2.8.1"), StarshipAirflow28)
     True
@@ -1234,6 +1242,8 @@ class StarshipCompatabilityLayer:
             )
 
         if int(major) == 2:
+            if int(minor) == 11:
+                return StarshipAirflow211()
             if int(minor) == 10:
                 return StarshipAirflow210()
             if int(minor) == 9:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "build",
 
     # test
-    "apache-airflow<2.11",     # Starship only supports Airflow version up to 2.10 at the moment
+    "apache-airflow<3",        # Starship only supports Airflow version up to 2.11 at the moment
     "pytest>=7",
     "pytest-cov>=4.0",
     "pytest-integration>=0.2",

--- a/tests/validation_test.py
+++ b/tests/validation_test.py
@@ -27,6 +27,7 @@ ASTRO_IMAGES = [
 ]
 
 IMAGES = [
+    "apache/airflow:slim-2.11.0",
     "apache/airflow:slim-2.10.3",
     "apache/airflow:slim-2.9.3",
     "apache/airflow:slim-2.8.1",


### PR DESCRIPTION
There haven't been significant changes to the DB or the model from 2.10 to 2.11. Therefore, we can use the same compatibility layer for Airflow 2.11 as we do for 2.10.
