### PR TITLE
feat: add experimental API for migrating task logs

### DIFF
--- a/astronomer_starship/__init__.py
+++ b/astronomer_starship/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 
 def get_provider_info():

--- a/astronomer_starship/compat/starship_compatability.py
+++ b/astronomer_starship/compat/starship_compatability.py
@@ -1225,7 +1225,7 @@ class StarshipAirflow28(StarshipAirflow27):
         map_index,
         try_number,
         **_,
-    ) -> tuple[str, str | None]:
+    ) -> "Tuple[str, str | None]":
         """Get the path to the task log file and the connection ID for remote storage."""
         ASTRONOMER_ENVIRONMENT = os.getenv("ASTRONOMER_ENVIRONMENT")
 
@@ -1257,6 +1257,9 @@ class StarshipAirflow28(StarshipAirflow27):
             res.status_code = 409
             raise NotImplementedError()
 
+        # ObjectStoragePath could be used to build the full path, but there seems to be a problem
+        # where the connection ID duplicates with each path segment.
+        # We also want to have access to the path only for logging purposes.
         path = os.path.join(
             base_folder,
             f"dag_id={dag_id}",

--- a/astronomer_starship/compat/starship_compatability.py
+++ b/astronomer_starship/compat/starship_compatability.py
@@ -1257,17 +1257,26 @@ class StarshipAirflow28(StarshipAirflow27):
             res.status_code = 409
             raise NotImplementedError()
 
+        path_components = (
+            [
+                f"dag_id={dag_id}",
+                f"run_id={run_id}",
+                f"task_id={task_id}",
+                f"attempt={try_number}.log",
+            ]
+            if map_index == "-1"
+            else [
+                f"dag_id={dag_id}",
+                f"run_id={run_id}",
+                f"task_id={task_id}",
+                f"map_index={map_index}",
+                f"attempt={try_number}.log",
+            ]
+        )
         # ObjectStoragePath could be used to build the full path, but there seems to be a problem
         # where the connection ID duplicates with each path segment.
         # We also want to have access to the path only for logging purposes.
-        path = os.path.join(
-            base_folder,
-            f"dag_id={dag_id}",
-            f"run_id={run_id}",
-            f"task_id={task_id}",
-            f"map_index={map_index}",
-            f"attempt={try_number}.log",
-        )
+        path = os.path.join(base_folder, *path_components)
         return path, conn_id
 
     def get_task_log(self, **kwargs):

--- a/astronomer_starship/compat/starship_compatability.py
+++ b/astronomer_starship/compat/starship_compatability.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 import json
 import logging
 import os
@@ -114,9 +115,11 @@ def results_to_list_via_attrs(
         json.dumps(
             [
                 {
-                    attr: getattr(result, attr_desc["attr"], None)
-                    if attr_desc["attr"]
-                    else None
+                    attr: (
+                        getattr(result, attr_desc["attr"], None)
+                        if attr_desc["attr"]
+                        else None
+                    )
                     for attr, attr_desc in attrs.items()
                 }
                 for result in results
@@ -414,9 +417,11 @@ class StarshipAirflow:
                             attr: (
                                 self._get_tags(result.dag_id)
                                 if attr == "tags"
-                                else self._get_dag_run_count(result.dag_id)
-                                if attr == "dag_run_count"
-                                else getattr(result, attr_desc["attr"], None)
+                                else (
+                                    self._get_dag_run_count(result.dag_id)
+                                    if attr == "dag_run_count"
+                                    else getattr(result, attr_desc["attr"], None)
+                                )
                                 # e.g. result.dag_id
                             )
                             for attr, attr_desc in self.dag_attrs().items()
@@ -910,6 +915,28 @@ class StarshipAirflow:
         attrs = {self.task_instances_attrs()[k]["attr"]: v for k, v in kwargs.items()}
         return generic_delete(self.session, "airflow.models.TaskInstance", **attrs)
 
+    @classmethod
+    def task_log_attrs(cls) -> "Dict[str, AttrDesc]":
+        return {}
+
+    def get_task_log(self, **kwargs):
+        """Get the log for a task instance"""
+        res = jsonify({"error": "Task logs require Airflow 2.8 or later"})
+        res.status_code = 409
+        raise NotImplementedError()
+
+    def set_task_log(self, **kwargs):
+        """Set the log for a task instance"""
+        res = jsonify({"error": "Task logs require Airflow 2.8 or later"})
+        res.status_code = 409
+        raise NotImplementedError()
+
+    def delete_task_log(self, **kwargs):
+        """Delete the log for a task instance"""
+        res = jsonify({"error": "Task logs require Airflow 2.8 or later"})
+        res.status_code = 409
+        raise NotImplementedError()
+
     def insert_directly(self, table_name, items):
         from sqlalchemy.exc import InvalidRequestError
         from sqlalchemy import MetaData
@@ -1133,6 +1160,164 @@ class StarshipAirflow28(StarshipAirflow27):
             "test_value": 0,
         }
         return attrs
+
+    def task_log_attrs(cls) -> "Dict[str, AttrDesc]":
+        return {
+            "dag_id": {
+                "attr": "dag_id",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": "dag_0",
+            },
+            "run_id": {
+                "attr": "run_id",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": "manual__1970-01-01T00:00:00+00:00",
+            },
+            "task_id": {
+                "attr": "task_id",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": "task_id",
+            },
+            "map_index": {
+                "attr": "map_index",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": -1,
+            },
+            "try_number": {
+                "attr": "try_number",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": 0,
+            },
+            "log": {
+                "attr": "log",
+                "methods": [("POST", True)],
+                "test_value": "This is a test task log.",
+            },
+        }
+
+    @classmethod
+    def _task_log_path(
+        cls,
+        *,
+        dag_id,
+        run_id,
+        task_id,
+        map_index,
+        try_number,
+        **_,
+    ) -> tuple[str, str | None]:
+        """Get the path to the task log file and the connection ID for remote storage."""
+        ASTRONOMER_ENVIRONMENT = os.getenv("ASTRONOMER_ENVIRONMENT")
+
+        if ASTRONOMER_ENVIRONMENT == "cloud":
+            # Astro Hosted
+            base_folder = os.getenv("AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER")
+            conn_id = None
+            for key in [
+                "AIRFLOW_CONN_ASTRO_GCS_LOGGING",
+                "AIRFLOW_CONN_ASTRO_AZURE_LOGS",
+                "AIRFLOW_CONN_ASTRO_S3_LOGGING",
+            ]:
+                conn_id = os.getenv(key)
+                if conn_id is not None:
+                    break
+
+            if conn_id is None:
+                res = jsonify({"error": "No remote logging connection found."})
+                res.status_code = 409
+                raise NotImplementedError()
+        elif ASTRONOMER_ENVIRONMENT == "local":
+            # Local astro dev environment
+            base_folder = "/usr/local/airflow/logs"
+            conn_id = None
+        else:
+            res = jsonify(
+                {"error": "Task logs are only supported on Astronomer environments."}
+            )
+            res.status_code = 409
+            raise NotImplementedError()
+
+        path = os.path.join(
+            base_folder,
+            f"dag_id={dag_id}",
+            f"run_id={run_id}",
+            f"task_id={task_id}",
+            f"map_index={map_index}",
+            f"attempt={try_number}.log",
+        )
+        return path, conn_id
+
+    def get_task_log(self, **kwargs):
+        """Get the log for a task instance"""
+        from airflow.io.path import ObjectStoragePath
+
+        try:
+            path, conn_id = self._task_log_path(**kwargs)
+            remote_path = ObjectStoragePath(path, conn_id=conn_id)
+
+            with remote_path.open("r") as f:
+                kwargs["log"] = f.read()
+
+            return kwargs
+        except FileNotFoundError as e:
+            res = jsonify({"error": f"Task log at {path} not found: {e}"})
+            res.status_code = 404
+            return res
+
+    def set_task_log(self, **kwargs):
+        """Set the log for a task instance"""
+        from airflow.io.path import ObjectStoragePath
+
+        path, conn_id = self._task_log_path(**kwargs)
+        remote_path = ObjectStoragePath(path, conn_id=conn_id)
+
+        # If local file system, ensure the parent directories exist.
+        # Causes problems with remote storage (where it is not needed),
+        # as it requires bucket level permissions.
+        if conn_id is None:
+            remote_path.parent.mkdir(exist_ok=True, parents=True)
+
+        with remote_path.open("w") as f:
+            f.write(kwargs["log"])
+
+        # avoid the overhead of returning the log as a response
+        del kwargs["log"]
+        return kwargs
+
+    def delete_task_log(self, **kwargs):
+        """Delete the log for a task instance"""
+        from airflow.io.path import ObjectStoragePath
+
+        try:
+            path, conn_id = self._task_log_path(**kwargs)
+            remote_path = ObjectStoragePath(path, conn_id=conn_id)
+
+            remote_path.unlink()
+            return Response(status=HTTPStatus.NO_CONTENT)
+        except FileNotFoundError as e:
+            res = jsonify({"error": f"Task log at {path} not found: {e}"})
+            res.status_code = 404
+            return res
 
 
 class StarshipAirflow29(StarshipAirflow28):

--- a/astronomer_starship/starship_api.py
+++ b/astronomer_starship/starship_api.py
@@ -715,6 +715,107 @@ class StarshipApi(BaseView):
             ),
         )
 
+    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE)])
+    @expose("/task_log", methods=["GET", "POST", "DELETE"])
+    @csrf.exempt
+    def task_logs(self):
+        """
+        **EXPERIMENTAL**
+
+        Get, set or delete task logs.
+
+        **Requirements:**
+
+        - Airflow 2.8+
+        - Astro hosted deployments or local astro dev environment
+
+        ---
+
+        ### `GET /api/starship/task_log`
+
+        **Parameters:** Args
+
+        | Field (*=Required)       | Version | Type               | Example                              |
+        |--------------------------|---------|--------------------|--------------------------------------|
+        | dag_id*                  |         | str                | dag_0                                |
+        | run_id*                  |         | str                | scheduled__2025-06-30T20:00:00+00:00 |
+        | task_id*                 |         | str                | task_0                               |
+        | map_index*               |         | int                | -1                                   |
+        | try_number*              |         | int                | 1                                    |
+
+
+        **Response**:
+
+        ```json
+        {
+            "dag_id": "example_dag2",
+            "log": "[2025-06-30T21:02:11.417+0000] ... Task exited with return code 0\\n",
+            "map_index": "0",
+            "run_id": "scheduled__2025-06-30T20:00:00+00:00",
+            "task_id": "example_task",
+            "try_number": "1"
+        }
+        ```
+
+        ### `POST /api/starship/task_log`
+
+        **Parameters:** JSON
+
+        | Field (*=Required)       | Version | Type               | Example                              |
+        |--------------------------|---------|--------------------|--------------------------------------|
+        | dag_id*                  |         | str                | dag_0                                |
+        | run_id*                  |         | str                | scheduled__2025-06-30T20:00:00+00:00 |
+        | task_id*                 |         | str                | task_0                               |
+        | map_index*               |         | int                | -1                                   |
+        | try_number*              |         | int                | 1                                    |
+        | log*                     |         | str                | [2025-06-30] This is a task log.     |
+
+        **Request**:
+
+        ```json
+        {
+            "dag_id": "example_dag2",
+            "log": "[2025-06-30T21:02:11.417+0000] ... Task exited with return code 0\\n",
+            "map_index": "0",
+            "run_id": "scheduled__2025-06-30T20:00:00+00:00",
+            "task_id": "example_task",
+            "try_number": "1"
+        }
+        ```
+
+        **Response**:
+
+        ```json
+        {
+            "dag_id": "example_dag2",
+            "map_index": "0",
+            "run_id": "scheduled__2025-06-30T20:00:00+00:00",
+            "task_id": "example_task",
+            "try_number": "1"
+        }
+        ```
+
+        ### DELETE /api/starship/task_log
+
+        **Parameters:** Args
+
+        | Field (*=Required)       | Version | Type               | Example                              |
+        |--------------------------|---------|--------------------|--------------------------------------|
+        | dag_id*                  |         | str                | dag_0                                |
+        | run_id*                  |         | str                | scheduled__2025-06-30T20:00:00+00:00 |
+        | task_id*                 |         | str                | task_0                               |
+        | map_index*               |         | int                | -1                                   |
+        | try_number*              |         | int                | 1                                    |
+
+        **Response:** None
+        """
+        return starship_route(
+            get=starship_compat.get_task_log,
+            post=starship_compat.set_task_log,
+            delete=starship_compat.delete_task_log,
+            kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_log_attrs()),
+        )
+
 
 starship_compat = StarshipCompatabilityLayer()
 

--- a/dev/dags/example.py
+++ b/dev/dags/example.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+from airflow.decorators import dag, task
+from airflow.models import Param
+
+
+@task(map_index_template="{{ params.name }}")
+def example_task(name: str, rendered: str):
+    from airflow.operators.python import get_current_context
+
+    get_current_context()["params"]["name"] = name
+    msg = f"Hello {name}, with example_param={rendered}!"
+    print(msg)
+    return msg
+
+
+@dag(
+    schedule="@hourly",
+    start_date=datetime(2025, 6, 1),
+    catchup=False,
+    params={
+        "example_param": Param(
+            "default_value",
+            type="string",
+            description="An example parameter",
+        )
+    },
+)
+def example():
+    example_task(
+        rendered="{{ params.example_param }}",
+        name="Buzz Lightyear",
+    )
+
+
+example()

--- a/dev/dags/example_mapped.py
+++ b/dev/dags/example_mapped.py
@@ -26,7 +26,7 @@ def example_task(name: str, rendered: str):
         )
     },
 )
-def example_dag():
+def example_mapped():
     example_task.partial(
         rendered="{{ params.example_param }}",
     ).expand(
@@ -34,4 +34,4 @@ def example_dag():
     )
 
 
-example_dag()
+example_mapped()

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,7 @@
 # API
 
 ## Error Responses
+
 In the event of an error, the API will return a JSON response with an `error` key
 and an HTTP `status_code`. The `error` key will contain a message describing the error.
 
@@ -13,8 +14,8 @@ and an HTTP `status_code`. The `error` key will contain a message describing the
 | **`POST` Data Error**             | 400             | ```{"error": "Data Error", "error_message": ..., "kwargs": ...}```                          |
 | **`POST` SQL Error**              | 400             | ```{"error": "SQL Error", "error_message": ..., "kwargs": ...}```                           |
 
-
 ## Airflow Version
+
 ::: astronomer_starship.starship_api.StarshipApi.airflow_version
     options:
         show_root_toc_entry: false
@@ -23,6 +24,7 @@ and an HTTP `status_code`. The `error` key will contain a message describing the
         show_header: false
 
 ## Health
+
 ::: astronomer_starship.starship_api.StarshipApi.health
     options:
         show_root_toc_entry: false
@@ -31,6 +33,7 @@ and an HTTP `status_code`. The `error` key will contain a message describing the
         show_header: false
 
 ## Environment Variables
+
 ::: astronomer_starship.starship_api.StarshipApi.env_vars
     options:
         show_root_toc_entry: false
@@ -38,8 +41,8 @@ and an HTTP `status_code`. The `error` key will contain a message describing the
         show_source: false
         show_header: false
 
-
 ## Variable
+
 ::: astronomer_starship.starship_api.StarshipApi.variables
     options:
         show_root_toc_entry: false
@@ -48,6 +51,7 @@ and an HTTP `status_code`. The `error` key will contain a message describing the
         show_header: false
 
 ## Pools
+
 ::: astronomer_starship.starship_api.StarshipApi.pools
     options:
         show_root_toc_entry: false
@@ -56,6 +60,7 @@ and an HTTP `status_code`. The `error` key will contain a message describing the
         show_header: false
 
 ## Connections
+
 ::: astronomer_starship.starship_api.StarshipApi.connections
     options:
         show_root_toc_entry: false
@@ -64,6 +69,7 @@ and an HTTP `status_code`. The `error` key will contain a message describing the
         show_header: false
 
 ## DAGs
+
 ::: astronomer_starship.starship_api.StarshipApi.dags
     options:
         show_root_toc_entry: false
@@ -72,6 +78,7 @@ and an HTTP `status_code`. The `error` key will contain a message describing the
         show_header: false
 
 ## DAG Runs
+
 ::: astronomer_starship.starship_api.StarshipApi.dag_runs
     options:
         show_root_toc_entry: false
@@ -80,7 +87,17 @@ and an HTTP `status_code`. The `error` key will contain a message describing the
         show_header: false
 
 ## Task Instances
+
 ::: astronomer_starship.starship_api.StarshipApi.task_instances
+    options:
+        show_root_toc_entry: false
+        show_root_heading: false
+        show_source: false
+        show_header: false
+
+## Task Log
+
+::: astronomer_starship.starship_api.StarshipApi.task_logs
     options:
         show_root_toc_entry: false
         show_root_heading: false


### PR DESCRIPTION
Within Astronomer environments we can use ObjectStoragePath (Airflow 2.8+) to interact with task logs located in remote storage. This change introduces an experimental API to get, set, and delete task logs based on this capability.

This allows us to migrate task logs using the Starship API.