### PR TITLE
fix: don't reuse session across requests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,17 @@ manual_tests = pytest.mark.skipif(
 @pytest.fixture(scope="session")
 def project_root() -> Path:
     return Path(__file__).parent.parent
+
+
+@pytest.fixture()
+def app():
+    from airflow.www.app import create_app
+
+    app = create_app(testing=True)
+    yield app
+
+
+@pytest.fixture(autouse=True)
+def app_context(app):
+    with app.app_context():
+        yield

--- a/tests/docker_test/docker_test.py
+++ b/tests/docker_test/docker_test.py
@@ -1,4 +1,5 @@
 """NOTE: These tests run _inside docker containers_ generated from the validation_test.py file."""
+
 import json
 import os
 import pytest
@@ -13,6 +14,20 @@ from astronomer_starship.compat.starship_compatability import (
 docker_test = pytest.mark.skipif(
     not bool(os.getenv("DOCKER_TEST")), reason="Not inside Docker container under test"
 )
+
+
+@pytest.fixture()
+def app():
+    from airflow.www.app import create_app
+
+    app = create_app(testing=True)
+    yield app
+
+
+@pytest.fixture(autouse=True)
+def app_context(app):
+    with app.app_context():
+        yield
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Concurrent requests will cause a conflict as they both use the same session.

Discovered this issue while pausing DAGs asynchronously.