### PR TITLE
feat: add experimental API for migrating XComs

### DIFF
--- a/astronomer_starship/package-lock.json
+++ b/astronomer_starship/package-lock.json
@@ -41,7 +41,7 @@
         "stylelint": "^16.1.0",
         "stylelint-config-standard": "^36.0.0",
         "vite": "^5.0.8",
-        "vitest": "^1.2.2"
+        "vitest": "^1.6.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1753,14 +1753,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
-      "integrity": "sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "1.6.0",
-        "@vitest/utils": "1.6.0",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -1768,13 +1768,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.0.tgz",
-      "integrity": "sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "1.6.0",
+        "@vitest/utils": "1.6.1",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -1799,9 +1799,9 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/yocto-queue": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1812,9 +1812,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.0.tgz",
-      "integrity": "sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1827,9 +1827,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.0.tgz",
-      "integrity": "sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1840,9 +1840,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.0.tgz",
-      "integrity": "sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5092,9 +5092,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.12",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
-      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7358,9 +7358,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.0.tgz",
-      "integrity": "sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7381,17 +7381,17 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.0.tgz",
-      "integrity": "sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "1.6.0",
-        "@vitest/runner": "1.6.0",
-        "@vitest/snapshot": "1.6.0",
-        "@vitest/spy": "1.6.0",
-        "@vitest/utils": "1.6.0",
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
         "acorn-walk": "^8.3.2",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
@@ -7405,7 +7405,7 @@
         "tinybench": "^2.5.1",
         "tinypool": "^0.8.3",
         "vite": "^5.0.0",
-        "vite-node": "1.6.0",
+        "vite-node": "1.6.1",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -7420,8 +7420,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.6.0",
-        "@vitest/ui": "1.6.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/astronomer_starship/starship_api.py
+++ b/astronomer_starship/starship_api.py
@@ -797,6 +797,95 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_log_attrs()),
         )
 
+    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE)])
+    @expose("/xcom", methods=["GET", "POST", "DELETE"])
+    @csrf.exempt
+    def xcom(self):
+        """
+        **EXPERIMENTAL**
+
+        Get, set or delete XComs.
+
+        **Requirements:**
+
+        - Airflow 2.8+
+
+        ---
+
+        ### `GET /api/starship/xcom`
+
+        **Parameters:** Args
+
+        | Field (*=Required)       | Version | Type               | Example                              |
+        |--------------------------|---------|--------------------|--------------------------------------|
+        | dag_id*                  |         | str                | dag_0                                |
+        | run_id*                  |         | str                | scheduled__2025-06-30T20:00:00+00:00 |
+        | task_id*                 |         | str                | task_0                               |
+        | map_index*               |         | int                | -1                                   |
+
+        **Response**:
+
+        ```json
+        [
+            {
+                "dag_id": "example_xcom",
+                "key": "example_str",
+                "map_index": -1,
+                "run_id": "scheduled__2025-07-17T00:00:00+00:00",
+                "task_id": "run",
+                "value": "bnVsbA=="
+            }
+        ]
+        ```
+
+        ### `POST /api/starship/task_log`
+
+        **Parameters:** JSON
+
+        | Field (*=Required)       | Version | Type               | Example                              |
+        |--------------------------|---------|--------------------|--------------------------------------|
+        | dag_id*                  |         | str                | dag_0                                |
+        | run_id*                  |         | str                | scheduled__2025-06-30T20:00:00+00:00 |
+        | task_id*                 |         | str                | task_0                               |
+        | map_index*               |         | int                | -1                                   |
+        | key*                     |         | str                | return_value                         |
+        | value*                   |         | str                | bnVsbA==                             |
+
+        **Request**:
+
+        ```json
+        {
+            "dag_id": "example_dag2",
+            "log": "[2025-06-30T21:02:11.417+0000] ... Task exited with return code 0\\n",
+            "map_index": "0",
+            "run_id": "scheduled__2025-06-30T20:00:00+00:00",
+            "task_id": "example_task",
+            "try_number": "1"
+        }
+        ```
+
+        **Response**: None
+
+        ### DELETE /api/starship/task_log
+
+        **Parameters:** Args
+
+        | Field (*=Required)       | Version | Type               | Example                              |
+        |--------------------------|---------|--------------------|--------------------------------------|
+        | dag_id*                  |         | str                | dag_0                                |
+        | run_id*                  |         | str                | scheduled__2025-06-30T20:00:00+00:00 |
+        | task_id*                 |         | str                | task_0                               |
+        | map_index*               |         | int                | -1                                   |
+
+        **Response:** None
+        """
+        return starship_route(
+            get=starship_compat.get_xcom,
+            post=starship_compat.set_xcom,
+            delete=starship_compat.delete_xcom,
+            kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.xcom_attrs()),
+        )
+
 
 starship_compat = StarshipCompatabilityLayer()
 

--- a/dev/justfile
+++ b/dev/justfile
@@ -13,7 +13,7 @@ _build-image-local:
 
 # build an image suitable for deployment with starship installed as a wheel
 _build-image-remote: _build-wheel
-     @docker build -t starship-dev-remote -f Dockerfile --build-arg RUNTIME_VERSION={{RUNTIME_VERSION}} ../
+     @docker build -t starship-dev-remote --platform linux/amd64 -f Dockerfile --build-arg RUNTIME_VERSION={{RUNTIME_VERSION}} ../
 
 # build the wheel of local starship
 _build-wheel:


### PR DESCRIPTION
We rely on XCom's serialization and deserialization capabilities paired
with base64 encoding to exchange non-json serializable XCom's via json.

This approach also works with xcom pickling enabled.
