### PR TITLE
Update operator.md

### DIFF
--- a/astronomer_starship/__init__.py
+++ b/astronomer_starship/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 
 
 def get_provider_info():

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -25,7 +25,7 @@ Make a connection in Airflow with the following details:
 - **Host**: the URL of the homepage of Airflow (excluding `/home` on the end of the URL)
   - For example, if your deployment URL is `https://astronomer.astronomer.run/abcdt4ry/home`, you'll use `https://astronomer.astronomer.run/abcdt4ry`
 - **Schema**: `https`
-- **Extras**: `{"Authorization": "Bearer <token>"}`
+- **Extra**: `{"Authorization": "Bearer <token>"}`
 
 ## Usage
 1. Add the following DAG to your source environment:


### PR DESCRIPTION
The underlying field is `connection.extra`. "Extras" here can cause users to create a connection that can't be built.

Similar problem exists in [OSS docs](https://github.com/apache/airflow/pull/53942), including specifically for the http conn type.