### PR TITLE
fix: remove flask request context dependency from StarshipCompatabilityLayer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 default_language_version:
   python: python3
 
-default_stages: [commit, push]
+default_stages: [pre-commit, pre-push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -23,38 +23,38 @@ repos:
         args: ["--allow-missing-credentials"]
 
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
 
   - repo: https://github.com/sirosen/texthooks
-    rev: 0.5.0
+    rev: 0.7.1
     hooks: [ { id: fix-smartquotes }, { id: fix-ligatures } ]
 
   - repo: https://github.com/frnmst/md-toc
-    rev: 8.1.9
+    rev: 9.0.0
     hooks: [ { id: md-toc } ]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.261'
+    rev: 'v0.13.1'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 25.9.0
     hooks: [ { id: black, args: [--config=pyproject.toml] } ]
 
   - repo: https://github.com/PyCQA/bandit/
-    rev: 1.7.4
+    rev: 1.8.6
     hooks:
       - id: bandit
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.13.0
+    rev: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"

--- a/astronomer_starship/compat/starship_compatability.py
+++ b/astronomer_starship/compat/starship_compatability.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 import json
 from http import HTTPStatus
 import logging
@@ -197,17 +198,11 @@ class StarshipAirflow:
     and get created directly by StarshipCompatabilityLayer
     """
 
-    def __init__(self):
-        self._session = None
-
-    @property
+    @cached_property
     def session(self) -> Session:
         from airflow.settings import Session
 
-        if not self._session:
-            self._session = Session()
-
-        return self._session
+        return Session()
 
     @classmethod
     def get_airflow_version(cls):

--- a/astronomer_starship/compat/starship_compatability.py
+++ b/astronomer_starship/compat/starship_compatability.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 import json
 from http import HTTPStatus
 import logging
@@ -198,11 +197,16 @@ class StarshipAirflow:
     and get created directly by StarshipCompatabilityLayer
     """
 
-    @cached_property
+    def __init__(self):
+        self._session = None
+
+    @property
     def session(self) -> Session:
         from airflow.settings import Session
 
-        return Session()
+        if self._session is None:
+            self._session = Session()
+        return self._session
 
     @classmethod
     def get_airflow_version(cls):

--- a/astronomer_starship/compat/starship_compatability.py
+++ b/astronomer_starship/compat/starship_compatability.py
@@ -197,15 +197,17 @@ class StarshipAirflow:
     and get created directly by StarshipCompatabilityLayer
     """
 
+    def __init__(self):
+        self._session = None
+
     @property
     def session(self) -> Session:
-        from flask import g
         from airflow.settings import Session
 
-        if "airflow_session" not in g:
-            g.airflow_session = Session()
+        if not self._session:
+            self._session = Session()
 
-        return g.airflow_session
+        return self._session
 
     @classmethod
     def get_airflow_version(cls):

--- a/astronomer_starship/providers/starship/hooks/starship.py
+++ b/astronomer_starship/providers/starship/hooks/starship.py
@@ -4,7 +4,6 @@ Hooks for interacting with Starship migrations
 
 from abc import ABC, abstractmethod
 
-from functools import cached_property
 from typing import List
 
 from airflow.providers.http.hooks.http import HttpHook
@@ -74,9 +73,15 @@ class StarshipHook(ABC):
 class StarshipLocalHook(BaseHook, StarshipHook):
     """Hook to retrieve local Airflow data, which can then be sent to the Target Starship instance."""
 
-    @cached_property
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._starship_compat = None
+
+    @property
     def starship_compat(self):
-        return StarshipCompatabilityLayer()
+        if self._starship_compat is None:
+            self._starship_compat = StarshipCompatabilityLayer()
+        return self._starship_compat
 
     def get_variables(self):
         """

--- a/astronomer_starship/providers/starship/hooks/starship.py
+++ b/astronomer_starship/providers/starship/hooks/starship.py
@@ -73,21 +73,11 @@ class StarshipHook(ABC):
 class StarshipLocalHook(BaseHook, StarshipHook):
     """Hook to retrieve local Airflow data, which can then be sent to the Target Starship instance."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._starship_compat = None
-
-    @property
-    def starship_compat(self):
-        if self._starship_compat is None:
-            self._starship_compat = StarshipCompatabilityLayer()
-        return self._starship_compat
-
     def get_variables(self):
         """
         Get all variables from the local Airflow instance.
         """
-        return self.starship_compat.get_variables()
+        return StarshipCompatabilityLayer().get_variables()
 
     def set_variable(self, **kwargs):
         raise RuntimeError("Setting local data is not supported")
@@ -96,7 +86,7 @@ class StarshipLocalHook(BaseHook, StarshipHook):
         """
         Get all pools from the local Airflow instance.
         """
-        return self.starship_compat.get_pools()
+        return StarshipCompatabilityLayer().get_pools()
 
     def set_pool(self, **kwargs):
         raise RuntimeError("Setting local data is not supported")
@@ -106,7 +96,7 @@ class StarshipLocalHook(BaseHook, StarshipHook):
         """
         Get all connections from the local Airflow instance.
         """
-        return self.starship_compat.get_connections()
+        return StarshipCompatabilityLayer().get_connections()
 
     def set_connection(self, **kwargs):
         raise RuntimeError("Setting local data is not supported")
@@ -115,19 +105,21 @@ class StarshipLocalHook(BaseHook, StarshipHook):
         """
         Get all DAGs from the local Airflow instance.
         """
-        return self.starship_compat.get_dags()
+        return StarshipCompatabilityLayer().get_dags()
 
     def set_dag_is_paused(self, dag_id: str, is_paused: bool):
         """
         Set the paused status of a DAG in the local Airflow instance.
         """
-        return self.starship_compat.set_dag_is_paused(dag_id, is_paused)
+        return StarshipCompatabilityLayer().set_dag_is_paused(dag_id, is_paused)
 
     def get_dag_runs(self, dag_id: str, offset: int = 0, limit: int = 10) -> dict:
         """
         Get DAG runs from the local Airflow instance.
         """
-        return self.starship_compat.get_dag_runs(dag_id, offset=offset, limit=limit)
+        return StarshipCompatabilityLayer().get_dag_runs(
+            dag_id, offset=offset, limit=limit
+        )
 
     def set_dag_runs(self, dag_runs: list):
         raise RuntimeError("Setting local data is not supported")
@@ -136,7 +128,7 @@ class StarshipLocalHook(BaseHook, StarshipHook):
         """
         Get task instances from the local Airflow instance.
         """
-        return self.starship_compat.get_task_instances(
+        return StarshipCompatabilityLayer().get_task_instances(
             dag_id, offset=offset, limit=limit
         )
 

--- a/astronomer_starship/providers/starship/hooks/starship.py
+++ b/astronomer_starship/providers/starship/hooks/starship.py
@@ -1,6 +1,7 @@
 """
 Hooks for interacting with Starship migrations
 """
+
 from abc import ABC, abstractmethod
 
 from typing import List

--- a/astronomer_starship/providers/starship/hooks/starship.py
+++ b/astronomer_starship/providers/starship/hooks/starship.py
@@ -4,12 +4,14 @@ Hooks for interacting with Starship migrations
 
 from abc import ABC, abstractmethod
 
+from functools import cached_property
 from typing import List
 
 from airflow.providers.http.hooks.http import HttpHook
 from airflow.hooks.base import BaseHook
 
-from astronomer_starship.starship_api import starship_compat
+from astronomer_starship.compat.starship_compatability import StarshipCompatabilityLayer
+
 
 POOLS_ROUTE = "/api/starship/pools"
 CONNECTIONS_ROUTE = "/api/starship/connections"
@@ -72,11 +74,15 @@ class StarshipHook(ABC):
 class StarshipLocalHook(BaseHook, StarshipHook):
     """Hook to retrieve local Airflow data, which can then be sent to the Target Starship instance."""
 
+    @cached_property
+    def starship_compat(self):
+        return StarshipCompatabilityLayer()
+
     def get_variables(self):
         """
         Get all variables from the local Airflow instance.
         """
-        return starship_compat.get_variables()
+        return self.starship_compat.get_variables()
 
     def set_variable(self, **kwargs):
         raise RuntimeError("Setting local data is not supported")
@@ -85,7 +91,7 @@ class StarshipLocalHook(BaseHook, StarshipHook):
         """
         Get all pools from the local Airflow instance.
         """
-        return starship_compat.get_pools()
+        return self.starship_compat.get_pools()
 
     def set_pool(self, **kwargs):
         raise RuntimeError("Setting local data is not supported")
@@ -95,7 +101,7 @@ class StarshipLocalHook(BaseHook, StarshipHook):
         """
         Get all connections from the local Airflow instance.
         """
-        return starship_compat.get_connections()
+        return self.starship_compat.get_connections()
 
     def set_connection(self, **kwargs):
         raise RuntimeError("Setting local data is not supported")
@@ -104,19 +110,19 @@ class StarshipLocalHook(BaseHook, StarshipHook):
         """
         Get all DAGs from the local Airflow instance.
         """
-        return starship_compat.get_dags()
+        return self.starship_compat.get_dags()
 
     def set_dag_is_paused(self, dag_id: str, is_paused: bool):
         """
         Set the paused status of a DAG in the local Airflow instance.
         """
-        return starship_compat.set_dag_is_paused(dag_id, is_paused)
+        return self.starship_compat.set_dag_is_paused(dag_id, is_paused)
 
     def get_dag_runs(self, dag_id: str, offset: int = 0, limit: int = 10) -> dict:
         """
         Get DAG runs from the local Airflow instance.
         """
-        return starship_compat.get_dag_runs(dag_id, offset=offset, limit=limit)
+        return self.starship_compat.get_dag_runs(dag_id, offset=offset, limit=limit)
 
     def set_dag_runs(self, dag_runs: list):
         raise RuntimeError("Setting local data is not supported")
@@ -125,7 +131,9 @@ class StarshipLocalHook(BaseHook, StarshipHook):
         """
         Get task instances from the local Airflow instance.
         """
-        return starship_compat.get_task_instances(dag_id, offset=offset, limit=limit)
+        return self.starship_compat.get_task_instances(
+            dag_id, offset=offset, limit=limit
+        )
 
     def set_task_instances(self, task_instances: list):
         raise RuntimeError("Setting local data is not supported")

--- a/astronomer_starship/providers/starship/operators/starship.py
+++ b/astronomer_starship/providers/starship/operators/starship.py
@@ -1,4 +1,5 @@
 """Operators, TaskGroups, and DAGs for interacting with the Starship migrations."""
+
 import logging
 from datetime import datetime
 from typing import Any, Union, List

--- a/astronomer_starship/starship_api.py
+++ b/astronomer_starship/starship_api.py
@@ -218,7 +218,11 @@ class StarshipApi(BaseView):
         presigned_url = request.args.get("presigned_url", False)
         if presigned_url:
             try:
-                upload = requests.put(presigned_url, data=json.dumps(report))
+                upload = requests.put(
+                    presigned_url,
+                    data=json.dumps(report),
+                    timeout=30,
+                )
                 return upload.content, upload.status_code
             except requests.exceptions.ConnectionError as e:
                 return str(e), 400

--- a/astronomer_starship/starship_api.py
+++ b/astronomer_starship/starship_api.py
@@ -248,6 +248,7 @@ class StarshipApi(BaseView):
         2.11.0+astro.1
         ```
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(get=starship_compat.get_airflow_version)
 
     @expose("/info", methods=["GET"])
@@ -270,6 +271,7 @@ class StarshipApi(BaseView):
         }
         ```
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(get=starship_compat.get_info)
 
     # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_CONFIG)])
@@ -295,6 +297,7 @@ class StarshipApi(BaseView):
         ```
 
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(get=starship_compat.get_env_vars)
 
     # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_POOL)])
@@ -349,6 +352,7 @@ class StarshipApi(BaseView):
 
         **Response:** None
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(
             get=starship_compat.get_pools,
             post=starship_compat.set_pool,
@@ -407,6 +411,7 @@ class StarshipApi(BaseView):
 
         **Response:** None
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(
             get=starship_compat.get_variables,
             post=starship_compat.set_variable,
@@ -480,6 +485,7 @@ class StarshipApi(BaseView):
 
         **Response:** None
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(
             get=starship_compat.get_connections,
             post=starship_compat.set_connection,
@@ -537,6 +543,7 @@ class StarshipApi(BaseView):
         }
         ```
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(
             get=starship_compat.get_dags,
             patch=starship_compat.set_dag_is_paused,
@@ -639,6 +646,7 @@ class StarshipApi(BaseView):
 
         **Response:** None
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(
             get=starship_compat.get_dag_runs,
             post=starship_compat.set_dag_runs,
@@ -739,6 +747,7 @@ class StarshipApi(BaseView):
         | trigger_timeout          | >2.1    | date | 1970-01-01T00:00:00+00:00         |
         | executor_config          |         | str  |                                   |
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(
             get=starship_compat.get_task_instances,
             post=starship_compat.set_task_instances,
@@ -822,6 +831,7 @@ class StarshipApi(BaseView):
 
         **Response:** None
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(
             get=starship_compat.get_task_log,
             post=starship_compat.set_task_log,
@@ -911,6 +921,7 @@ class StarshipApi(BaseView):
 
         **Response:** None
         """
+        starship_compat = StarshipCompatabilityLayer()
         return starship_route(
             get=starship_compat.get_xcom,
             post=starship_compat.set_xcom,
@@ -918,8 +929,6 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.xcom_attrs()),
         )
 
-
-starship_compat = StarshipCompatabilityLayer()
 
 starship_api_view = StarshipApi()
 starship_api_bp = Blueprint(
@@ -936,3 +945,9 @@ class StarshipAPIPlugin(AirflowPlugin):
             "view": starship_api_view,
         }
     ]
+
+    @classmethod
+    def on_load(cls, *args, **kwargs):
+        # Initialize compatibility layer on plugin load to ensure it loads fine.
+        # If not, a runtime error will be raised, disabling the plugin.
+        StarshipCompatabilityLayer()

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -31,9 +31,13 @@ Make a connection in Airflow with the following details:
 1. Add the following DAG to your source environment:
 
     ```python title="dags/starship_airflow_migration_dag.py"
-    from astronomer_starship.providers.starship.operators.starship import StarshipAirflowMigrationDAG
+    from astronomer_starship.providers.starship.operators.starship import (
+        StarshipAirflowMigrationDAG,
+    )
 
-    globals()['starship_airflow_migration_dag'] = StarshipAirflowMigrationDAG(http_conn_id="starship_default")
+    globals()["starship_airflow_migration_dag"] = StarshipAirflowMigrationDAG(
+        http_conn_id="starship_default"
+    )
     ```
 
 2. Unpause the DAG in the Airflow UI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Migrations to Astro"
 authors = [
     { name = "Fritz Davenport", email = "fritz@astronomer.io" },
     { name = "CETA Team", email = "ceta@astronomer.io" },
-    { name = "Astronomer", email = "humans@astronomer.io" }
+    { name = "Astronomer", email = "humans@astronomer.io" },
 ]
 readme = "README.md"
 license = { text = "PROPRIETARY" }
@@ -35,16 +35,21 @@ version = { attr = "astronomer_starship.__version__" }
 [tool.setuptools.packages.find]
 include = ["astronomer_starship", "astronomer_starship.*"]
 exclude = [
-    "*venv*", "*venv*.*",
-    "*tests.*", "*tests",
-    "*build", "*build.*",
-    "*dist", "*dist.*",
-    "*node_modules", "*node_modules.*",
+    "*venv*",
+    "*venv*.*",
+    "*tests.*",
+    "*tests",
+    "*build",
+    "*build.*",
+    "*dist",
+    "*dist.*",
+    "*node_modules",
+    "*node_modules.*",
 ]
 
 [project.optional-dependencies]
 provider = [
-    "apache-airflow-providers-http"
+    "apache-airflow-providers-http",
 ]
 
 dev = [
@@ -54,6 +59,7 @@ dev = [
 
     # test
     "apache-airflow<3",        # Starship only supports Airflow version up to 2.11 at the moment
+    "flask_limiter<3.13",      # A breaking change was introduced in version 3.13 of flask-limiter
     "pytest>=7",
     "pytest-cov>=4.0",
     "pytest-integration>=0.2",
@@ -78,7 +84,6 @@ dev = [
     "isort>=5",
 ]
 
-
 # for pip installing this pyproject.toml
 [project.entry-points."airflow.plugins"]
 "starship" = "astronomer_starship.starship:StarshipPlugin"
@@ -97,7 +102,7 @@ skips = [
     "B301",
     "B403",
     "B310", # urlopen in Aeroscope
-    "B608"  # SQL Injection in DAG History Migration
+    "B608", # SQL Injection in DAG History Migration
 ]
 
 [tool.ruff]
@@ -105,8 +110,17 @@ line-length = 120
 
 [tool.pytest.ini_options]
 norecursedirs = [
-    "tests/docker_test/", "tests/resources/", "hooks", "*.egg", ".eggs",
-    "dist", "build", "docs", ".tox", ".git", "__pycache__"
+    "tests/docker_test/",
+    "tests/resources/",
+    "hooks",
+    "*.egg",
+    ".eggs",
+    "dist",
+    "build",
+    "docs",
+    ".tox",
+    ".git",
+    "__pycache__",
 ]
 doctest_optionflags = ["NUMBER", "NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,17 +10,3 @@ manual_tests = pytest.mark.skipif(
 @pytest.fixture(scope="session")
 def project_root() -> Path:
     return Path(__file__).parent.parent
-
-
-@pytest.fixture()
-def app():
-    from airflow.www.app import create_app
-
-    app = create_app(testing=True)
-    yield app
-
-
-@pytest.fixture(autouse=True)
-def app_context(app):
-    with app.app_context():
-        yield

--- a/tests/docker_test/docker_test.py
+++ b/tests/docker_test/docker_test.py
@@ -16,20 +16,6 @@ docker_test = pytest.mark.skipif(
 )
 
 
-@pytest.fixture()
-def app():
-    from airflow.www.app import create_app
-
-    app = create_app(testing=True)
-    yield app
-
-
-@pytest.fixture(autouse=True)
-def app_context(app):
-    with app.app_context():
-        yield
-
-
 @pytest.fixture(scope="session")
 def starship():
     return StarshipCompatabilityLayer()


### PR DESCRIPTION
When the compatibility layer is being used by a Starship DAG (or anything else outside Flask), then there
is no Flask request context.

As an alternative, we can create a per-request compatibility layer instance
and return to a per instance DB session. This will also avoid the initial
issue where DB sessions were shared across concurrent requests (https://github.com/astronomer/starship/pull/131).
