### PR TITLE
fix: avoid race condition pushing TIs and TI history

### DIFF
--- a/astronomer_starship/__init__.py
+++ b/astronomer_starship/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 
 
 def get_provider_info():

--- a/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
+++ b/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
@@ -120,18 +120,25 @@ function DAGHistoryMigrateButton({
           throw new Error('Failed to create DAG runs');
         }
 
-        await Promise.all([
-          axios.post(
-            proxyUrl(url + constants.TASK_INSTANCE_ROUTE),
-            { task_instances: taskInstanceRes.data.task_instances },
-            { params: { dag_id: dagId }, headers: proxyHeaders(token) },
-          ),
-          axios.post(
-            proxyUrl(url + constants.TASK_INSTANCE_HISTORY_ROUTE),
-            { task_instances: taskInstanceHistoryRes.data.task_instances },
-            { params: { dag_id: dagId }, headers: proxyHeaders(token) },
-          ),
-        ]);
+        const taskInstanceCreateRes = await axios.post(
+          proxyUrl(url + constants.TASK_INSTANCE_ROUTE),
+          { task_instances: taskInstanceRes.data.task_instances },
+          { params: { dag_id: dagId }, headers: proxyHeaders(token) },
+        );
+
+        if (taskInstanceCreateRes.status !== 200) {
+          throw new Error('Failed to create task instances');
+        }
+
+        const taskInstanceHistoryCreateRes = await axios.post(
+          proxyUrl(url + constants.TASK_INSTANCE_HISTORY_ROUTE),
+          { task_instances: taskInstanceHistoryRes.data.task_instances },
+          { params: { dag_id: dagId }, headers: proxyHeaders(token) },
+        );
+
+        if (taskInstanceHistoryCreateRes.status !== 200) {
+          throw new Error('Failed to create task instance history');
+        }
 
         const migratedCount = dagRunCreateRes.data.dag_run_count;
         const newProgress = Math.min(

--- a/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
+++ b/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
@@ -141,13 +141,13 @@ function DAGHistoryMigrateButton({
         }
 
         const migratedCount = dagRunCreateRes.data.dag_run_count;
-        const newProgress = Math.min(
-          99,
-          Math.round((migratedCount / dagRunsToMigrateCount) * 100),
-        );
-        setProgress(newProgress);
 
         if (migratedCount < dagRunsToMigrateCount) {
+          const newProgress = Math.min(
+            99,
+            Math.round((migratedCount / dagRunsToMigrateCount) * 100),
+          );
+          setProgress(newProgress);
           await migrateBatch(offset + batchSize, dagRunsToMigrateCount);
         } else {
           setProgress(100);


### PR DESCRIPTION
TI history records rely on the corresponding TI's to be present.
Therefore we can only push TI history after successfully pushing TIs.