### PR TITLE
Fix Dag History table column display and migrate button state

### DIFF
--- a/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
+++ b/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
@@ -23,7 +23,7 @@ import constants from '../constants';
 export const DISABLED_REASONS = Object.freeze({
   NOT_IN_REMOTE: {
     key: 'NOT_IN_REMOTE',
-    tooltip: 'DAG not found in remote.',
+    tooltip: 'Deploy DAG to remote before migrating',
     buttonText: 'Not on Remote',
   },
   NO_DAG_RUNS: {

--- a/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
+++ b/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
@@ -24,7 +24,7 @@ export const DISABLED_REASONS = Object.freeze({
   NOT_IN_REMOTE: {
     key: 'NOT_IN_REMOTE',
     tooltip: 'DAG not found in remote.',
-    buttonText: 'Not Found',
+    buttonText: 'Not on Remote',
   },
   NO_DAG_RUNS: {
     key: 'NO_DAG_RUNS',

--- a/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
+++ b/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
@@ -44,11 +44,12 @@ function DAGHistoryMigrateButton({
   limit = 1000,
   batchSize = 100,
   existsInRemote = false,
-  isDisabled = false,
   disabledReason = null,
   onMigrate = null,
   onDelete = null,
 }) {
+  // Derive isDisabled from disabledReason to avoid inconsistency
+  const isDisabled = Boolean(disabledReason);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState(null);
   const toast = useToast();
@@ -204,7 +205,7 @@ function DAGHistoryMigrateButton({
       );
     }
     if (exists) return 'Delete';
-    if (isDisabled && disabledReason) {
+    if (disabledReason) {
       return disabledReason.buttonText || 'Disabled';
     }
     if (error) return 'Error!';
@@ -264,12 +265,11 @@ DAGHistoryMigrateButton.propTypes = {
   limit: PropTypes.number,
   batchSize: PropTypes.number,
   existsInRemote: PropTypes.bool,
-  isDisabled: PropTypes.bool,
   disabledReason: PropTypes.shape({
     key: PropTypes.string,
     tooltip: PropTypes.string,
     buttonText: PropTypes.string,
-  }), // Object from DISABLED_REASONS enum
+  }),
   onMigrate: PropTypes.func,
   onDelete: PropTypes.func,
 };

--- a/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
+++ b/astronomer_starship/src/component/DAGHistoryMigrateButton.jsx
@@ -17,6 +17,23 @@ import { localRoute, proxyHeaders, proxyUrl } from '../util';
 import constants from '../constants';
 
 /**
+ * Constants for DAG History migration button disabled states.
+ * Each reason includes the key, tooltip message, and button text.
+ */
+export const DISABLED_REASONS = Object.freeze({
+  NOT_IN_REMOTE: {
+    key: 'NOT_IN_REMOTE',
+    tooltip: 'DAG not found in remote.',
+    buttonText: 'Not Found',
+  },
+  NO_DAG_RUNS: {
+    key: 'NO_DAG_RUNS',
+    tooltip: 'No DAG Runs to migrate',
+    buttonText: 'Nothing to Migrate',
+  },
+});
+
+/**
  * Migrate button specifically for DAG history migration.
  * Handles batch migration of DAG runs, task instances, and task instance history.
  */
@@ -28,6 +45,7 @@ function DAGHistoryMigrateButton({
   batchSize = 100,
   existsInRemote = false,
   isDisabled = false,
+  disabledReason = null,
   onMigrate = null,
   onDelete = null,
 }) {
@@ -186,7 +204,9 @@ function DAGHistoryMigrateButton({
       );
     }
     if (exists) return 'Delete';
-    if (isDisabled) return 'Not Found';
+    if (isDisabled && disabledReason) {
+      return disabledReason.buttonText || 'Disabled';
+    }
     if (error) return 'Error!';
     return 'Migrate';
   };
@@ -197,8 +217,10 @@ function DAGHistoryMigrateButton({
   const activeBorderColor = isDeleteMode || error ? 'error.500' : 'success.500';
   const activeHoverBg = isDeleteMode || error ? 'error.50' : 'success.50';
 
+  const tooltipText = disabledReason?.tooltip || '';
+
   return (
-    <WithTooltip isDisabled={isDisabled}>
+    <WithTooltip isDisabled={isDisabled} tooltipText={tooltipText}>
       <Button
         size="sm"
         variant="outline"
@@ -227,7 +249,7 @@ function DAGHistoryMigrateButton({
           opacity: 1,
         }}
         onClick={handleClick}
-        minW={isLoading ? '130px' : undefined}
+        minW={isLoading ? '130px' : isDisabled ? '150px' : undefined}
       >
         {renderContent()}
       </Button>
@@ -242,7 +264,12 @@ DAGHistoryMigrateButton.propTypes = {
   limit: PropTypes.number,
   batchSize: PropTypes.number,
   existsInRemote: PropTypes.bool,
-  isDisabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  isDisabled: PropTypes.bool,
+  disabledReason: PropTypes.shape({
+    key: PropTypes.string,
+    tooltip: PropTypes.string,
+    buttonText: PropTypes.string,
+  }), // Object from DISABLED_REASONS enum
   onMigrate: PropTypes.func,
   onDelete: PropTypes.func,
 };

--- a/astronomer_starship/src/component/DataTable.jsx
+++ b/astronomer_starship/src/component/DataTable.jsx
@@ -115,7 +115,7 @@ export default function DataTable({
           {rightElement}
         </HStack>
       )}
-      <TableContainer className="data-table">
+      <TableContainer className="data-table" overflowX="auto" maxW="100%">
         <Table variant="striped" size="sm">
           <Thead>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -129,7 +129,8 @@ export default function DataTable({
                       onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
                       isNumeric={meta?.isNumeric}
                       textAlign={meta?.align || (meta?.isNumeric ? 'right' : 'left')}
-                      width={meta?.width || 'auto'}
+                      width={meta?.width}
+                      minW={meta?.minWidth}
                       cursor={canSort ? 'pointer' : 'default'}
                     >
                       {header.isPlaceholder
@@ -166,7 +167,10 @@ export default function DataTable({
                         key={cell.id}
                         isNumeric={meta?.isNumeric}
                         textAlign={meta?.align || (meta?.isNumeric ? 'right' : 'left')}
-                        width={meta?.width || 'auto'}
+                        width={meta?.width}
+                        minW={meta?.minWidth}
+                        whiteSpace="normal"
+                        wordBreak="break-word"
                       >
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
                       </Td>

--- a/astronomer_starship/src/component/ProgressSummary.jsx
+++ b/astronomer_starship/src/component/ProgressSummary.jsx
@@ -12,6 +12,7 @@ import {
   Icon,
   Spacer,
 } from '@chakra-ui/react';
+import { CheckCircleIcon } from '@chakra-ui/icons';
 import { FiUpload } from 'react-icons/fi';
 
 function StatFeature({ label, value, color = 'gray.700' }) {
@@ -39,6 +40,7 @@ export default function ProgressSummary({
 }) {
   const remainingItems = totalItems - migratedItems;
   const progressPercentage = totalItems > 0 ? (migratedItems / totalItems) * 100 : 0;
+  const isComplete = migratedItems === totalItems && totalItems > 0;
 
   return (
     <Card mb={4} bg="brand.10" borderWidth={1} borderColor="brand.100">
@@ -70,14 +72,17 @@ export default function ProgressSummary({
                 <Text fontSize="xs" color="gray.600" textTransform="uppercase" letterSpacing="wide">
                   Migration Progress
                 </Text>
-                <Text fontSize="xs" color="gray.500">
-                  {`${progressPercentage.toFixed(0)}%`}
-                </Text>
+                <HStack spacing={1}>
+                  <Text fontSize="xs" color="gray.500">
+                    {`${progressPercentage.toFixed(0)}%`}
+                  </Text>
+                  <Text fontSize="xs" color="gray.600">{isComplete ? <Icon as={CheckCircleIcon} color="green.500" /> : null}</Text>
+                </HStack>
               </HStack>
               <Progress
                 value={progressPercentage}
                 size="md"
-                colorScheme="brand"
+                colorScheme={isComplete ? 'success' : 'brand'}
                 borderRadius="full"
                 bg="gray.100"
                 hasStripe={isMigratingAll}

--- a/astronomer_starship/src/component/ProgressSummary.jsx
+++ b/astronomer_starship/src/component/ProgressSummary.jsx
@@ -12,7 +12,6 @@ import {
   Icon,
   Spacer,
 } from '@chakra-ui/react';
-import { CheckCircleIcon } from '@chakra-ui/icons';
 import { FiUpload } from 'react-icons/fi';
 
 function StatFeature({ label, value, color = 'gray.700' }) {
@@ -40,7 +39,6 @@ export default function ProgressSummary({
 }) {
   const remainingItems = totalItems - migratedItems;
   const progressPercentage = totalItems > 0 ? (migratedItems / totalItems) * 100 : 0;
-  const isComplete = migratedItems === totalItems && totalItems > 0;
 
   return (
     <Card mb={4} bg="brand.10" borderWidth={1} borderColor="brand.100">
@@ -72,17 +70,14 @@ export default function ProgressSummary({
                 <Text fontSize="xs" color="gray.600" textTransform="uppercase" letterSpacing="wide">
                   Migration Progress
                 </Text>
-                <HStack spacing={1}>
-                  <Text fontSize="xs" color="gray.500">
-                    {`${progressPercentage.toFixed(0)}%`}
-                  </Text>
-                  <Text fontSize="xs" color="gray.600">{isComplete ? <Icon as={CheckCircleIcon} color="green.500" /> : null}</Text>
-                </HStack>
+                <Text fontSize="xs" color="gray.500">
+                  {`${progressPercentage.toFixed(0)}%`}
+                </Text>
               </HStack>
               <Progress
                 value={progressPercentage}
                 size="md"
-                colorScheme={isComplete ? 'success' : 'brand'}
+                colorScheme="brand"
                 borderRadius="full"
                 bg="gray.100"
                 hasStripe={isMigratingAll}

--- a/astronomer_starship/src/component/WithTooltip.jsx
+++ b/astronomer_starship/src/component/WithTooltip.jsx
@@ -4,17 +4,18 @@ import PropTypes from 'prop-types';
 
 /**
  * Wrapper component that conditionally renders a tooltip around children.
- * If isDisabled is a truthy string, shows a tooltip with that string as label.
+ * If isDisabled is true and tooltipText is provided, shows a tooltip.
  * Otherwise, renders children directly without a tooltip.
  */
-function WithTooltip({ isDisabled = false, children }) {
-  return isDisabled ? (
-    <Tooltip hasArrow label={isDisabled}>{children}</Tooltip>
+function WithTooltip({ isDisabled = false, tooltipText = '', children }) {
+  return isDisabled && tooltipText ? (
+    <Tooltip hasArrow label={tooltipText}>{children}</Tooltip>
   ) : children;
 }
 
 WithTooltip.propTypes = {
-  isDisabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  isDisabled: PropTypes.bool,
+  tooltipText: PropTypes.string,
   children: PropTypes.node.isRequired,
 };
 

--- a/astronomer_starship/src/pages/ConnectionsPage.jsx
+++ b/astronomer_starship/src/pages/ConnectionsPage.jsx
@@ -29,26 +29,46 @@ function renderHiddenValue(info) {
  */
 function createColumns(targetUrl, token, handleItemStatusChange) {
   return [
-    columnHelper.accessor('conn_id', { header: 'Connection ID' }),
-    columnHelper.accessor('conn_type', { header: 'Type' }),
-    columnHelper.accessor('host', { header: 'Host' }),
-    columnHelper.accessor('port', { header: 'Port' }),
-    columnHelper.accessor('schema', { header: 'Schema' }),
-    columnHelper.accessor('login', { header: 'Login' }),
+    columnHelper.accessor('conn_id', {
+      header: 'Connection ID',
+      meta: { minWidth: '150px' },
+    }),
+    columnHelper.accessor('conn_type', {
+      header: 'Type',
+      meta: { minWidth: '100px' },
+    }),
+    columnHelper.accessor('host', {
+      header: 'Host',
+      meta: { minWidth: '150px' },
+    }),
+    columnHelper.accessor('port', {
+      header: 'Port',
+      meta: { minWidth: '80px' },
+    }),
+    columnHelper.accessor('schema', {
+      header: 'Schema',
+      meta: { minWidth: '100px' },
+    }),
+    columnHelper.accessor('login', {
+      header: 'Login',
+      meta: { minWidth: '120px' },
+    }),
     columnHelper.accessor('password', {
       header: 'Password',
       cell: renderHiddenValue,
+      meta: { minWidth: '100px' },
       enableSorting: false,
     }),
     columnHelper.accessor('extra', {
       header: 'Extra',
       cell: renderHiddenValue,
+      meta: { minWidth: '100px' },
       enableSorting: false,
     }),
     columnHelper.display({
       id: 'migrate',
       header: 'Migrate',
-      meta: { align: 'right' },
+      meta: { align: 'right', width: '120px' },
       enableSorting: false,
       cell: (info) => {
         const { original } = info.row;

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -34,7 +34,7 @@ import { useAppDispatch, useTargetConfig, useDagHistoryConfig } from '../AppCont
 import DataTable from '../component/DataTable';
 import PageLoading from '../component/PageLoading';
 import TooltipHeader from '../component/TooltipHeader';
-import DAGHistoryMigrateButton from '../component/DAGHistoryMigrateButton';
+import DAGHistoryMigrateButton, { DISABLED_REASONS } from '../component/DAGHistoryMigrateButton';
 import {
   localRoute, proxyHeaders, proxyUrl, getDagViewPath,
 } from '../util';
@@ -88,24 +88,29 @@ function createColumns(config) {
       id: 'dagId',
       header: 'ID',
       cell: renderDagId,
+      meta: { minWidth: '150px' },
     }),
     columnHelper.accessor((row) => row.local.tags, {
       id: 'tags',
       header: 'Tags',
       cell: renderTags,
+      meta: { minWidth: '120px' },
     }),
     columnHelper.accessor((row) => row.local.schedule_interval, {
       id: 'schedule',
       header: 'Schedule',
       cell: renderSchedule,
+      meta: { minWidth: '100px' },
     }),
     columnHelper.accessor((row) => row.local.description, {
       id: 'description',
       header: 'Description',
+      meta: { minWidth: '200px' },
     }),
     columnHelper.accessor((row) => row.local.owners, {
       id: 'owners',
       header: 'Owners',
+      meta: { minWidth: '120px' },
     }),
     columnHelper.display({
       id: 'local_is_paused',
@@ -116,6 +121,7 @@ function createColumns(config) {
           <TooltipHeader tooltip="Toggle to pause/unpause DAG in local" />
         </>
       ),
+      meta: { width: '100px' },
       cell: (info) => {
         const { original } = info.row;
         return (
@@ -146,6 +152,7 @@ function createColumns(config) {
     columnHelper.display({
       id: 'local_url',
       header: 'Local URL',
+      meta: { width: '110px' },
       enableSorting: false,
       cell: (info) => {
         const { original } = info.row;
@@ -171,6 +178,7 @@ function createColumns(config) {
           <TooltipHeader tooltip="Toggle to pause/unpause DAG in remote" />
         </>
       ),
+      meta: { width: '100px' },
       cell: (info) => {
         const { original } = info.row;
         if (!original.remote) return null;
@@ -202,6 +210,7 @@ function createColumns(config) {
     columnHelper.display({
       id: 'remote_url',
       header: 'Remote URL',
+      meta: { width: '110px' },
       enableSorting: false,
       cell: (info) => {
         const { original } = info.row;
@@ -222,17 +231,21 @@ function createColumns(config) {
     columnHelper.display({
       id: 'migrate',
       header: 'Migrate',
-      meta: { align: 'right' },
+      meta: { align: 'right', width: '170px' },
       enableSorting: false,
       cell: (info) => {
         const { original } = info.row;
 
         // Determine disabled state
-        let isDisabledReason = false;
+        let isDisabled = false;
+        let disabledReason = null;
+
         if (!original.remote?.dag_id) {
-          isDisabledReason = 'DAG not found in remote';
+          isDisabled = true;
+          disabledReason = DISABLED_REASONS.NOT_IN_REMOTE;
         } else if (!original.local.dag_run_count && !original.remote?.dag_run_count) {
-          isDisabledReason = 'No DAG Runs to migrate';
+          isDisabled = true;
+          disabledReason = DISABLED_REASONS.NO_DAG_RUNS;
         }
 
         return (
@@ -243,7 +256,8 @@ function createColumns(config) {
             limit={Number(limit)}
             batchSize={Number(batchSize)}
             existsInRemote={!!original.remote?.dag_run_count}
-            isDisabled={isDisabledReason}
+            isDisabled={isDisabled}
+            disabledReason={disabledReason}
             onMigrate={handleMigrate}
             onDelete={handleDelete}
           />
@@ -330,6 +344,8 @@ export default function DAGHistoryPage() {
   const handleMigrate = useCallback((dagId, runCount) => {
     setData((prev) => prev.map((item) => {
       if (item.local.dag_id !== dagId) return item;
+      // Only update dag_run_count if remote exists, otherwise keep remote as null
+      if (!item.remote) return item;
       return { ...item, remote: { ...item.remote, dag_run_count: runCount } };
     }));
   }, []);
@@ -337,6 +353,8 @@ export default function DAGHistoryPage() {
   const handleDelete = useCallback((dagId) => {
     setData((prev) => prev.map((item) => {
       if (item.local.dag_id !== dagId) return item;
+      // Only update dag_run_count if remote exists, otherwise keep remote as null
+      if (!item.remote) return item;
       return { ...item, remote: { ...item.remote, dag_run_count: 0 } };
     }));
   }, []);

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -236,15 +236,11 @@ function createColumns(config) {
       cell: (info) => {
         const { original } = info.row;
 
-        // Determine disabled state
-        let isDisabled = false;
         let disabledReason = null;
 
         if (!original.remote?.dag_id) {
-          isDisabled = true;
           disabledReason = DISABLED_REASONS.NOT_IN_REMOTE;
         } else if (!original.local.dag_run_count && !original.remote?.dag_run_count) {
-          isDisabled = true;
           disabledReason = DISABLED_REASONS.NO_DAG_RUNS;
         }
 
@@ -256,7 +252,6 @@ function createColumns(config) {
             limit={Number(limit)}
             batchSize={Number(batchSize)}
             existsInRemote={!!original.remote?.dag_run_count}
-            isDisabled={isDisabled}
             disabledReason={disabledReason}
             onMigrate={handleMigrate}
             onDelete={handleDelete}

--- a/astronomer_starship/src/pages/EnvVarsPage.jsx
+++ b/astronomer_starship/src/pages/EnvVarsPage.jsx
@@ -49,16 +49,20 @@ function createColumns(config) {
   } = config;
 
   return [
-    columnHelper.accessor('key', { header: 'Key' }),
+    columnHelper.accessor('key', {
+      header: 'Key',
+      meta: { minWidth: '150px' },
+    }),
     columnHelper.accessor('value', {
       header: 'Value',
       cell: renderHiddenValue,
+      meta: { minWidth: '200px' },
       enableSorting: false,
     }),
     columnHelper.display({
       id: 'migrate',
       header: 'Migrate',
-      meta: { align: 'right' },
+      meta: { align: 'right', width: '120px' },
       enableSorting: false,
       cell: (info) => {
         const { original } = info.row;

--- a/astronomer_starship/src/pages/PoolsPage.jsx
+++ b/astronomer_starship/src/pages/PoolsPage.jsx
@@ -21,13 +21,22 @@ const columnHelper = createColumnHelper();
  */
 function createColumns(targetUrl, token, handleItemStatusChange) {
   return [
-    columnHelper.accessor('name', { header: 'Name' }),
-    columnHelper.accessor('slots', { header: 'Slots' }),
-    columnHelper.accessor('description', { header: 'Description' }),
+    columnHelper.accessor('name', {
+      header: 'Name',
+      meta: { minWidth: '150px' },
+    }),
+    columnHelper.accessor('slots', {
+      header: 'Slots',
+      meta: { minWidth: '80px' },
+    }),
+    columnHelper.accessor('description', {
+      header: 'Description',
+      meta: { minWidth: '200px' },
+    }),
     columnHelper.display({
       id: 'migrate',
       header: 'Migrate',
-      meta: { align: 'right' },
+      meta: { align: 'right', width: '120px' },
       enableSorting: false,
       cell: (info) => {
         const { original } = info.row;

--- a/astronomer_starship/src/pages/VariablesPage.jsx
+++ b/astronomer_starship/src/pages/VariablesPage.jsx
@@ -21,12 +21,18 @@ const columnHelper = createColumnHelper();
  */
 function createColumns(targetUrl, token, handleItemStatusChange) {
   return [
-    columnHelper.accessor('key', { header: 'Key' }),
-    columnHelper.accessor('val', { header: 'Value' }),
+    columnHelper.accessor('key', {
+      header: 'Key',
+      meta: { minWidth: '150px' },
+    }),
+    columnHelper.accessor('val', {
+      header: 'Value',
+      meta: { minWidth: '200px' },
+    }),
     columnHelper.display({
       id: 'migrate',
       header: 'Migrate',
-      meta: { align: 'right' },
+      meta: { align: 'right', width: '120px' },
       enableSorting: false,
       cell: (info) => {
         const { original } = info.row;

--- a/astronomer_starship/src/utils/dagUtils.js
+++ b/astronomer_starship/src/utils/dagUtils.js
@@ -6,13 +6,18 @@
  */
 export default function mergeDagData(localData, remoteData) {
   const output = {};
+
+  // Add all local DAGs first (these are the DAGs we can migrate FROM)
   localData.forEach((item) => {
     output[item.dag_id] = { local: item, remote: null };
   });
+
+  // Then merge in remote DAG data where it exists
   remoteData.forEach((item) => {
     if (output[item.dag_id]) {
       output[item.dag_id].remote = item;
     }
   });
+
   return Object.values(output);
 }

--- a/dev2/dags/ui_testing_dag.py
+++ b/dev2/dags/ui_testing_dag.py
@@ -1,0 +1,103 @@
+"""
+## This is an extremely long DAG description designed specifically to test UI display limits
+
+This DAG was created for the sole purpose of testing how the Airflow UI handles
+extremely long text values in various fields such as the DAG name, description,
+owner, and other metadata fields. It is important to verify that the UI can
+gracefully handle overflow, truncation, tooltips, and other display mechanisms
+when dealing with unusually long strings that might be encountered in
+production environments where users may not always follow naming conventions.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum.
+
+This description continues with more text to really push the limits of the UI
+rendering capabilities. The goal is to see if scrollbars appear, if text gets
+truncated with ellipsis, or if the layout breaks in any unexpected way.
+"""
+
+from airflow.decorators import dag, task
+from pendulum import datetime
+
+
+VERY_LONG_OWNER_NAME = (
+    "John Jacob Jingleheimer Schmidt Senior Junior III Esquire PhD MBA "
+    "Chief Executive Officer President Vice President Director Manager "
+    "Supervisor Team Lead Principal Staff Senior Distinguished Fellow "
+    "Architect Engineer Developer Administrator Consultant Specialist"
+)
+
+
+@dag(
+    dag_id=(
+        "this_is_an_extremely_long_dag_name_designed_to_test_how_the_airflow_"
+        "ui_handles_very_long_dag_identifiers_which_should_never_be_used_in_"
+        "production_but_we_are_testing_edge_cases_to_ensure_proper_truncation_"
+        "and_overflow_handling_in_all_ui_views_249_char"
+    ),  # Exactly 249 characters
+    start_date=datetime(2024, 1, 1),
+    # Using a complex cron schedule to test schedule display
+    schedule="0 0 1,15 1,2,3,4,5,6,7,8,9,10,11,12 1,2,3,4,5",
+    catchup=False,
+    doc_md=__doc__,
+    default_args={
+        "owner": VERY_LONG_OWNER_NAME,
+        "retries": 3,
+    },
+    tags=[
+        "test",
+        "ui-display-test",
+        "very-long-tag-name-that-should-test-tag-overflow-behavior",
+        "another-extremely-long-tag-that-nobody-would-ever-use-in-real-life",
+        "edge-case",
+        "stress-test",
+        "overflow-test",
+        "truncation-test",
+    ],
+    description=(
+        "This is an incredibly verbose and excessively long description that "
+        "is meant to test how the Airflow scheduler and web UI handle DAGs "
+        "with extremely lengthy description strings that would normally never "
+        "be written by any reasonable developer but might occur accidentally "
+        "or through automated DAG generation tools or configuration systems "
+        "that do not impose reasonable length limits on their output fields."
+    ),
+)
+def this_is_an_extremely_long_dag_name_that_tests_ui():
+    """
+    DAG function with a long name to test function name display.
+    """
+
+    @task
+    def task_with_a_very_long_name_that_is_designed_to_test_task_name_overflow_and_truncation_behavior_in_the_graph_view_and_grid_view():
+        """
+        A simple task with an extremely long name.
+
+        :return: A confirmation message.
+        :rtype: str
+        """
+        return "Task completed successfully!"
+
+    @task
+    def another_long_task_name_for_additional_ui_stress_testing_purposes_to_verify_consistent_behavior_across_multiple_tasks(
+        message: str,
+    ):
+        """
+        A second task that depends on the first.
+
+        :param message: Message from upstream task.
+        :type message: str
+        """
+        print(f"Received: {message}")
+
+    result = task_with_a_very_long_name_that_is_designed_to_test_task_name_overflow_and_truncation_behavior_in_the_graph_view_and_grid_view()
+    another_long_task_name_for_additional_ui_stress_testing_purposes_to_verify_consistent_behavior_across_multiple_tasks(
+        result
+    )
+
+
+this_is_an_extremely_long_dag_name_that_tests_ui()

--- a/dev2/dags/ui_testing_dag.py
+++ b/dev2/dags/ui_testing_dag.py
@@ -23,7 +23,6 @@ truncated with ellipsis, or if the layout breaks in any unexpected way.
 from airflow.decorators import dag, task
 from pendulum import datetime
 
-
 VERY_LONG_OWNER_NAME = (
     "John Jacob Jingleheimer Schmidt Senior Junior III Esquire PhD MBA "
     "Chief Executive Officer President Vice President Director Manager "


### PR DESCRIPTION
- Fix the Dag History data table column width display issue
    -  Dags with very long Dag ID, description, owner, tags will now display properly
    - Column width is now responsive with a minimum value
    - Button columns have fixed widths to ensure displaying properly
    - The tables will overflow with a horizontal scrollbar if the content is wider than the page

- Fix the Dag History Migrate button's disabled states and disabled reason
    - Distinguish between "Not found on remote" and "Nothing to migrate"
    
    
<img width="1880" height="872" alt="image" src="https://github.com/user-attachments/assets/9b83547c-f83d-42c2-8a0c-bdbf1b8366bc" />
