### PR TITLE
Add task logs support in Airflow 3

### DIFF
--- a/astronomer_starship/__init__.py
+++ b/astronomer_starship/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.8.4"
+__version__ = "2.9.0"
 
 
 def get_provider_info():

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -645,7 +645,7 @@ class StarshipAirflow(BaseStarshipAirflow):
     def task_instance_history_attrs(cls) -> "Dict[str, AttrDesc]":
         return cls.task_instances_attrs()
 
-    def get_task_instance_history(self, dag_id: str, **kwargs):
+    def get_task_instance_history(self, dag_id: str, offset: int = 0, limit: int = 10):
         """Get task instance history records."""
         # Before Airflow 2.10, we just return an empty list
         return {
@@ -653,7 +653,7 @@ class StarshipAirflow(BaseStarshipAirflow):
             "dag_run_count": self._get_dag_run_count(dag_id),
         }
 
-    def set_task_instance_history(self, **kwargs):
+    def set_task_instance_history(self, task_instances: list):
         """Set task instance history records."""
         # Before Airflow 2.10, we do nothing
         return {"task_instances": []}

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -11,6 +11,7 @@ from astronomer_starship.common import (
     NotFoundError,
     generic_delete,
     results_to_list_via_attrs,
+    run_id_sub_query,
     task_log_path,
 )
 
@@ -602,22 +603,12 @@ class StarshipAirflow(BaseStarshipAirflow):
         }
 
     def get_task_instances(self, dag_id: str, offset: int = 0, limit: int = 10):
-        from airflow.models import DagRun, TaskInstance
+        from airflow.models import TaskInstance
         from sqlalchemy import desc
         from sqlalchemy.orm import load_only
 
         try:
-            # py36/sqlalchemy1.3 doesn't query(Table.column)
-            # noinspection PyTypeChecker
-            sub_query = (
-                self.session.query(DagRun.run_id)
-                .filter(DagRun.dag_id == dag_id)
-                .order_by(desc(DagRun.start_date))
-                .limit(limit)
-            )
-            if offset:
-                sub_query = sub_query.offset(offset)
-            sub_query = sub_query.subquery()
+            sub_query = run_id_sub_query(dag_id, limit, offset, self.session)
 
             # .in_ doesn't seem to get recognized by type checkers
             # noinspection PyUnresolvedReferences
@@ -1209,23 +1200,12 @@ class StarshipAirflow210(StarshipAirflow29):
 
     def get_task_instance_history(self, dag_id: str, offset: int = 0, limit: int = 10):
         """Get task instance history records."""
-        from airflow.models import DagRun
         from airflow.models.taskinstancehistory import TaskInstanceHistory
         from sqlalchemy import desc
         from sqlalchemy.orm import load_only
 
         try:
-            # py36/sqlalchemy1.3 doesn't query(Table.column)
-            # noinspection PyTypeChecker
-            sub_query = (
-                self.session.query(DagRun.run_id)
-                .filter(DagRun.dag_id == dag_id)
-                .order_by(desc(DagRun.start_date))
-                .limit(limit)
-            )
-            if offset:
-                sub_query = sub_query.offset(offset)
-            sub_query = sub_query.subquery()
+            sub_query = run_id_sub_query(dag_id, limit, offset, self.session)
 
             # .in_ doesn't seem to get recognized by type checkers
             # noinspection PyUnresolvedReferences

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import logging
-import os
 from typing import TYPE_CHECKING
 
 import pytz
@@ -12,10 +11,11 @@ from astronomer_starship.common import (
     NotFoundError,
     generic_delete,
     results_to_list_via_attrs,
+    task_log_path,
 )
 
 if TYPE_CHECKING:
-    from typing import Dict, Tuple, Union
+    from typing import Dict, Union
 
     from astronomer_starship.common import AttrDesc
 
@@ -980,71 +980,13 @@ class StarshipAirflow28(StarshipAirflow27):
             },
         }
 
-    @classmethod
-    def _task_log_path(
-        cls,
-        *,
-        dag_id,
-        run_id,
-        task_id,
-        map_index,
-        try_number,
-        **_,
-    ) -> "Tuple[str, str | None]":
-        """Get the path to the task log file and the connection ID for remote storage."""
-        astronomer_environment = os.getenv("ASTRONOMER_ENVIRONMENT")
-
-        if astronomer_environment == "cloud":
-            # Astro Hosted
-            base_folder = os.getenv("AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER")
-            conn_id = None
-            for key in [
-                "AIRFLOW_CONN_ASTRO_GCS_LOGGING",
-                "AIRFLOW_CONN_ASTRO_AZURE_LOGS",
-                "AIRFLOW_CONN_ASTRO_S3_LOGGING",
-            ]:
-                conn_id = os.getenv(key)
-                if conn_id is not None:
-                    break
-
-            if conn_id is None:
-                raise ConflictError("No remote logging connection found.")
-        elif astronomer_environment == "local":
-            # Local astro dev environment
-            base_folder = "/usr/local/airflow/logs"
-            conn_id = None
-        else:
-            raise ConflictError("Task logs are only supported on Astronomer environments.")
-
-        path_components = (
-            [
-                f"dag_id={dag_id}",
-                f"run_id={run_id}",
-                f"task_id={task_id}",
-                f"attempt={try_number}.log",
-            ]
-            if map_index == "-1"
-            else [
-                f"dag_id={dag_id}",
-                f"run_id={run_id}",
-                f"task_id={task_id}",
-                f"map_index={map_index}",
-                f"attempt={try_number}.log",
-            ]
-        )
-        # ObjectStoragePath could be used to build the full path, but there seems to be a problem
-        # where the connection ID duplicates with each path segment.
-        # We also want to have access to the path only for logging purposes.
-        path = os.path.join(base_folder, *path_components)
-        return path, conn_id
-
     def get_task_log(self, **kwargs):
         """Get the log for a task instance"""
         from airflow.io.path import ObjectStoragePath
         from flask import Response
 
         try:
-            path, conn_id = self._task_log_path(**kwargs)
+            path, conn_id = task_log_path(**kwargs)
             remote_path = ObjectStoragePath(path, conn_id=conn_id)
             size = remote_path.size()
             logger.debug("Task log at %s has %d bytes", path, size)
@@ -1070,7 +1012,7 @@ class StarshipAirflow28(StarshipAirflow27):
         from airflow.io.path import ObjectStoragePath
         from flask import request
 
-        path, conn_id = self._task_log_path(**kwargs)
+        path, conn_id = task_log_path(**kwargs)
         remote_path = ObjectStoragePath(path, conn_id=conn_id)
         block_size = int(kwargs.get("block_size", 1024 * 1024))
 
@@ -1093,7 +1035,7 @@ class StarshipAirflow28(StarshipAirflow27):
         from airflow.io.path import ObjectStoragePath
 
         try:
-            path, conn_id = self._task_log_path(**kwargs)
+            path, conn_id = task_log_path(**kwargs)
             remote_path = ObjectStoragePath(path, conn_id=conn_id)
 
             remote_path.unlink()

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import os
 from typing import TYPE_CHECKING
 
 import pytz
@@ -12,7 +13,7 @@ from astronomer_starship.common import (
     generic_delete,
     results_to_list_via_attrs,
     run_id_sub_query,
-    task_log_path,
+    task_log_base_path,
 )
 
 if TYPE_CHECKING:
@@ -662,15 +663,15 @@ class StarshipAirflow(BaseStarshipAirflow):
     def task_log_attrs(cls) -> "Dict[str, AttrDesc]":
         return {}
 
-    def get_task_log(self, **kwargs):
+    def get_task_log(self, filename: str, **kwargs):
         """Get the log for a task instance"""
         raise ConflictError("Task logs require Airflow 2.8 or later")
 
-    def set_task_log(self, **kwargs):
+    def set_task_log(self, filename: str, **kwargs):
         """Set the log for a task instance"""
         raise ConflictError("Task logs require Airflow 2.8 or later")
 
-    def delete_task_log(self, **kwargs):
+    def delete_task_log(self, filename: str, **kwargs):
         """Delete the log for a task instance"""
         raise ConflictError("Task logs require Airflow 2.8 or later")
 
@@ -952,14 +953,14 @@ class StarshipAirflow28(StarshipAirflow27):
                 ],
                 "test_value": -1,
             },
-            "try_number": {
-                "attr": "try_number",
+            "filename": {
+                "attr": "filename",
                 "methods": [
                     ("GET", True),
                     ("POST", True),
                     ("DELETE", True),
                 ],
-                "test_value": 0,
+                "test_value": "attempt=1.log",
             },
             "block_size": {
                 "attr": "block_size",
@@ -971,13 +972,14 @@ class StarshipAirflow28(StarshipAirflow27):
             },
         }
 
-    def get_task_log(self, **kwargs):
+    def get_task_log(self, filename: str, **kwargs):
         """Get the log for a task instance"""
         from airflow.io.path import ObjectStoragePath
         from flask import Response
 
         try:
-            path, conn_id = task_log_path(**kwargs)
+            base_path, conn_id = task_log_base_path(**kwargs)
+            path = os.path.join(base_path, filename)
             remote_path = ObjectStoragePath(path, conn_id=conn_id)
             size = remote_path.size()
             logger.debug("Task log at %s has %d bytes", path, size)
@@ -998,12 +1000,13 @@ class StarshipAirflow28(StarshipAirflow27):
         except FileNotFoundError as e:
             raise NotFoundError(f"Task log at {path} not found: {e}") from e
 
-    def set_task_log(self, **kwargs):
+    def set_task_log(self, filename: str, **kwargs):
         """Set the log for a task instance"""
         from airflow.io.path import ObjectStoragePath
         from flask import request
 
-        path, conn_id = task_log_path(**kwargs)
+        base_path, conn_id = task_log_base_path(**kwargs)
+        path = os.path.join(base_path, filename)
         remote_path = ObjectStoragePath(path, conn_id=conn_id)
         block_size = int(kwargs.get("block_size", 1024 * 1024))
 
@@ -1021,12 +1024,13 @@ class StarshipAirflow28(StarshipAirflow27):
                     break
                 f.write(data)
 
-    def delete_task_log(self, **kwargs):
+    def delete_task_log(self, filename: str, **kwargs):
         """Delete the log for a task instance"""
         from airflow.io.path import ObjectStoragePath
 
         try:
-            path, conn_id = task_log_path(**kwargs)
+            base_path, conn_id = task_log_base_path(**kwargs)
+            path = os.path.join(base_path, filename)
             remote_path = ObjectStoragePath(path, conn_id=conn_id)
 
             remote_path.unlink()

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -915,6 +915,71 @@ class StarshipAirflow28(StarshipAirflow27):
         return attrs
 
     @classmethod
+    def task_log_files_attrs(cls) -> "Dict[str, AttrDesc]":
+        epoch = datetime.datetime(1970, 1, 1, 0, 0)
+        epoch = epoch.replace(tzinfo=pytz.utc)
+        return {
+            "dag_id": {
+                "attr": "dag_id",
+                "methods": [("GET", True), ("DELETE", True)],
+                "test_value": "dag_0",
+            },
+            "limit": {
+                "attr": None,
+                "methods": [("GET", False)],
+                "test_value": 10,
+            },
+            "offset": {
+                "attr": None,
+                "methods": [("GET", False)],
+                "test_value": 0,
+            },
+        }
+
+    def get_task_log_files(self, dag_id: str, offset: int = 0, limit: int = 10):
+        from airflow.io.path import ObjectStoragePath
+        from airflow.models import TaskInstance
+        from sqlalchemy import desc
+        from sqlalchemy.orm import noload
+
+        sub_query = run_id_sub_query(dag_id, limit, offset, self.session)
+
+        task_instances = (
+            self.session.query(TaskInstance)
+            .filter(TaskInstance.dag_id == dag_id)
+            .filter(TaskInstance.run_id.in_(sub_query))
+            .options(noload("*"))
+            .order_by(desc(TaskInstance.start_date))
+            .all()
+        )
+
+        results = []
+
+        for ti in task_instances:
+            path, conn_id = task_log_base_path(
+                dag_id=ti.dag_id,
+                run_id=ti.run_id,
+                task_id=ti.task_id,
+                map_index=ti.map_index,
+            )
+
+            for p in ObjectStoragePath(path, conn_id=conn_id).iterdir():
+                results.append(
+                    {
+                        "dag_id": ti.dag_id,
+                        "run_id": ti.run_id,
+                        "task_id": ti.task_id,
+                        "map_index": ti.map_index,
+                        "filename": p.name,
+                    }
+                )
+
+        return {
+            "task_log_files": results,
+            "dag_run_count": self._get_dag_run_count(dag_id),
+        }
+
+    @classmethod
     def task_log_attrs(cls) -> "Dict[str, AttrDesc]":
         return {
             "dag_id": {

--- a/astronomer_starship/_af3/starship_api.py
+++ b/astronomer_starship/_af3/starship_api.py
@@ -272,6 +272,17 @@ class StarshipApi(FastAPI):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_instance_history_attrs()),
         )
 
+    @router.api_route("/task_log_files", methods=["GET"])
+    @staticmethod
+    def task_log_files(
+        starship_route: Annotated[StarshipRoute, Depends(starship_route)],
+        starship_compat: Annotated[StarshipAirflow, Depends(starship_compat)],
+    ):
+        return starship_route(
+            get=starship_compat.get_task_log_files,
+            kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_log_files_attrs()),
+        )
+
     @router.api_route("/task_log", methods=["GET", "POST", "DELETE"])
     @staticmethod
     def task_logs(

--- a/astronomer_starship/_af3/starship_api.py
+++ b/astronomer_starship/_af3/starship_api.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Annotated
 
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.plugins_manager import AirflowPlugin
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 
 from astronomer_starship._af3.starship_compatability import StarshipAirflow, StarshipCompatabilityLayer
@@ -94,6 +94,8 @@ class StarshipRoute:
 
             if res is None:
                 return None
+            elif isinstance(res, Response):
+                return res
 
             return JSONResponse(res)
         except HttpError as e:

--- a/astronomer_starship/_af3/starship_api.py
+++ b/astronomer_starship/_af3/starship_api.py
@@ -114,6 +114,13 @@ class StarshipRoute:
             )
 
 
+async def request_body(request: Request) -> bytes | None:
+    """async 'dependable' to get request body"""
+    # TODO can we return a sync generator which internally uses async streaming?
+    body = await request.body()
+    return body if body else None
+
+
 async def starship_route(request: Request) -> StarshipRoute:
     """async 'dependable' to build StarshipRoute from Request"""
     content_type = request.headers.get("Content-Type")
@@ -268,6 +275,7 @@ class StarshipApi(FastAPI):
     @router.api_route("/task_log", methods=["GET", "POST", "DELETE"])
     @staticmethod
     def task_logs(
+        body: Annotated[bytes | None, Depends(request_body)],
         starship_route: Annotated[StarshipRoute, Depends(starship_route)],
         starship_compat: Annotated[StarshipAirflow, Depends(starship_compat)],
     ):
@@ -275,7 +283,7 @@ class StarshipApi(FastAPI):
             get=starship_compat.get_task_log,
             post=starship_compat.set_task_log,
             delete=starship_compat.delete_task_log,
-            kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_log_attrs()),
+            kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_log_attrs(), body=body),
         )
 
     @router.api_route("/xcom", methods=["GET", "POST", "DELETE"])

--- a/astronomer_starship/_af3/starship_api.py
+++ b/astronomer_starship/_af3/starship_api.py
@@ -116,11 +116,12 @@ class StarshipRoute:
 
 async def starship_route(request: Request) -> StarshipRoute:
     """async 'dependable' to build StarshipRoute from Request"""
-    body = await request.body()
+    content_type = request.headers.get("Content-Type")
+    is_json = content_type == "application/json"
     return StarshipRoute(
         method=request.method,
         args=(request.query_params if request.method in ["GET", "POST", "DELETE"] else {}),
-        json=await request.json() if body else {},
+        json=await request.json() if is_json else {},
     )
 
 

--- a/astronomer_starship/_af3/starship_api.py
+++ b/astronomer_starship/_af3/starship_api.py
@@ -12,7 +12,7 @@ from astronomer_starship._af3.starship_compatability import StarshipAirflow, Sta
 from astronomer_starship.common import HttpError, get_kwargs_fn, telescope
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from typing import Callable, Optional
 
 
 @dataclass
@@ -30,7 +30,7 @@ class StarshipRoute:
         put=None,
         delete=None,
         patch=None,
-        kwargs_fn: "Callable[[dict, dict], dict]" = None,
+        kwargs_fn: "Optional[Callable[[dict, dict], dict]]" = None,
     ):
         try:
             # noinspection PyArgumentList

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -1,15 +1,18 @@
 import datetime
 import json
 import logging
+import os
 from typing import TYPE_CHECKING, Optional
 
 import pytz
 
 from astronomer_starship.common import (
     BaseStarshipAirflow,
+    NotFoundError,
     generic_delete,
     results_to_list_via_attrs,
     run_id_sub_query,
+    task_log_base_path,
 )
 
 if TYPE_CHECKING:
@@ -946,6 +949,126 @@ class StarshipAirflow30(StarshipAirflow):
     def set_task_instance_history(self, task_instances: list):
         task_instances = self.insert_directly("task_instance_history", task_instances)
         return {"task_instances": task_instances}
+
+    @classmethod
+    def task_log_attrs(cls) -> "Dict[str, AttrDesc]":
+        return {
+            "dag_id": {
+                "attr": "dag_id",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": "dag_0",
+            },
+            "run_id": {
+                "attr": "run_id",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": "manual__1970-01-01T00:00:00+00:00",
+            },
+            "task_id": {
+                "attr": "task_id",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": "task_id",
+            },
+            "map_index": {
+                "attr": "map_index",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": -1,
+            },
+            "filename": {
+                "attr": "filename",
+                "methods": [
+                    ("GET", True),
+                    ("POST", True),
+                    ("DELETE", True),
+                ],
+                "test_value": "attempt=1.log",
+            },
+            "block_size": {
+                "attr": "block_size",
+                "methods": [
+                    ("GET", False),
+                    ("POST", False),
+                ],
+                "test_value": 1024 * 1024,
+            },
+        }
+
+    def get_task_log(self, filename: str, **kwargs):
+        """Get the log for a task instance"""
+        from airflow.sdk import ObjectStoragePath
+        from fastapi.responses import StreamingResponse
+
+        try:
+            base_path, conn_id = task_log_base_path(**kwargs)
+            path = os.path.join(base_path, filename)
+            remote_path = ObjectStoragePath(path, conn_id=conn_id)
+            size = remote_path.size()
+            logger.debug("Task log at %s has %d bytes", path, size)
+            block_size = int(kwargs.get("block_size", 1024 * 1024))
+
+            def generator():
+                offset = 0
+
+                with remote_path.open("rb") as f:
+                    while offset < size:
+                        data = f.read(block_size)
+                        logger.info("Yielding %d bytes at offset %d", len(data), offset)
+                        yield data
+
+                        offset += block_size
+
+            return StreamingResponse(generator(), media_type="text/plain")
+        except FileNotFoundError as e:
+            raise NotFoundError(f"Task log at {path} not found: {e}") from e
+
+    def set_task_log(self, filename: str, **kwargs):
+        """Set the log for a task instance"""
+        from airflow.sdk import ObjectStoragePath
+
+        body: bytes = kwargs.pop("body")
+        base_path, conn_id = task_log_base_path(**kwargs)
+        path = os.path.join(base_path, filename)
+        remote_path = ObjectStoragePath(path, conn_id=conn_id)
+
+        # If local file system, ensure the parent directories exist.
+        # Causes problems with remote storage (where it is not needed),
+        # as it requires bucket level permissions.
+        if conn_id is None:
+            remote_path.parent.mkdir(exist_ok=True, parents=True)
+
+        # There is no point in streaming the body, because due to the
+        # way Starship is currently integrated with FastAPI, the body
+        # is already in memory.
+        with remote_path.open("wb") as f:
+            f.write(body)
+
+    def delete_task_log(self, filename: str, **kwargs):
+        """Delete the log for a task instance"""
+        from airflow.sdk import ObjectStoragePath
+
+        try:
+            base_path, conn_id = task_log_base_path(**kwargs)
+            path = os.path.join(base_path, filename)
+            remote_path = ObjectStoragePath(path, conn_id=conn_id)
+
+            remote_path.unlink()
+        except FileNotFoundError as e:
+            raise NotFoundError(f"Task log at {path} not found: {e}") from e
 
     def insert_directly(self, table_name, items):  # noqa: C901
         import pickle

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -9,6 +9,7 @@ from astronomer_starship.common import (
     BaseStarshipAirflow,
     generic_delete,
     results_to_list_via_attrs,
+    run_id_sub_query,
 )
 
 if TYPE_CHECKING:
@@ -651,35 +652,16 @@ class StarshipAirflow30(StarshipAirflow):
         import json
 
         from airflow.models import TaskInstance
-        from sqlalchemy import MetaData, String, desc, select
+        from sqlalchemy import desc
+        from sqlalchemy.orm import noload
 
         try:
-            engine = self.session.get_bind()
-            metadata = MetaData(bind=engine)
-
-            metadata.reflect(engine, only=["dag_run"])
-            dag_run_table = metadata.tables["dag_run"]
-            dag_run_table.c.triggered_by.type = String(50)
-
-            sub_stmt = (
-                select(dag_run_table.c.run_id)
-                .where(dag_run_table.c.dag_id == dag_id)
-                .order_by(desc(dag_run_table.c.start_date))
-                .limit(limit)
-            )
-            if offset:
-                sub_stmt = sub_stmt.offset(offset)
-
-            run_ids_result = self.session.execute(sub_stmt)
-            run_ids = [row[0] for row in run_ids_result]
-
-            # Use noload() to prevent eager loading
-            from sqlalchemy.orm import noload
+            sub_query = run_id_sub_query(dag_id, limit, offset, self.session)
 
             results = (
                 self.session.query(TaskInstance)
                 .filter(TaskInstance.dag_id == dag_id)
-                .filter(TaskInstance.run_id.in_(run_ids))
+                .filter(TaskInstance.run_id.in_(sub_query))
                 .options(noload("*"))
                 .order_by(desc(TaskInstance.start_date))
                 .all()
@@ -938,21 +920,12 @@ class StarshipAirflow30(StarshipAirflow):
         }
 
     def get_task_instance_history(self, dag_id: str, offset: int = 0, limit: int = 10):
-        from airflow.models import DagRun
         from airflow.models.taskinstancehistory import TaskInstanceHistory
         from sqlalchemy import desc
         from sqlalchemy.orm import noload
 
         try:
-            sub_query = (
-                self.session.query(DagRun.run_id)
-                .filter(DagRun.dag_id == dag_id)
-                .order_by(desc(DagRun.start_date))
-                .limit(limit)
-            )
-            if offset:
-                sub_query = sub_query.offset(offset)
-            sub_query = sub_query.subquery()
+            sub_query = run_id_sub_query(dag_id, limit, offset, self.session)
 
             results = (
                 self.session.query(TaskInstanceHistory)

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -951,6 +951,71 @@ class StarshipAirflow30(StarshipAirflow):
         return {"task_instances": task_instances}
 
     @classmethod
+    def task_log_files_attrs(cls) -> "Dict[str, AttrDesc]":
+        epoch = datetime.datetime(1970, 1, 1, 0, 0)
+        epoch = epoch.replace(tzinfo=pytz.utc)
+        return {
+            "dag_id": {
+                "attr": "dag_id",
+                "methods": [("GET", True), ("DELETE", True)],
+                "test_value": "dag_0",
+            },
+            "limit": {
+                "attr": None,
+                "methods": [("GET", False)],
+                "test_value": 10,
+            },
+            "offset": {
+                "attr": None,
+                "methods": [("GET", False)],
+                "test_value": 0,
+            },
+        }
+
+    def get_task_log_files(self, dag_id: str, offset: int = 0, limit: int = 10):
+        from airflow.models import TaskInstance
+        from airflow.sdk import ObjectStoragePath
+        from sqlalchemy import desc
+        from sqlalchemy.orm import noload
+
+        sub_query = run_id_sub_query(dag_id, limit, offset, self.session)
+
+        task_instances = (
+            self.session.query(TaskInstance)
+            .filter(TaskInstance.dag_id == dag_id)
+            .filter(TaskInstance.run_id.in_(sub_query))
+            .options(noload("*"))
+            .order_by(desc(TaskInstance.start_date))
+            .all()
+        )
+
+        results = []
+
+        for ti in task_instances:
+            path, conn_id = task_log_base_path(
+                dag_id=ti.dag_id,
+                run_id=ti.run_id,
+                task_id=ti.task_id,
+                map_index=ti.map_index,
+            )
+
+            for p in ObjectStoragePath(path, conn_id=conn_id).iterdir():
+                results.append(
+                    {
+                        "dag_id": ti.dag_id,
+                        "run_id": ti.run_id,
+                        "task_id": ti.task_id,
+                        "map_index": ti.map_index,
+                        "filename": p.name,
+                    }
+                )
+
+        return {
+            "task_log_files": results,
+            "dag_run_count": self._get_dag_run_count(dag_id),
+        }
+
+    @classmethod
     def task_log_attrs(cls) -> "Dict[str, AttrDesc]":
         return {
             "dag_id": {

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import pytz
 
@@ -1029,7 +1029,7 @@ class StarshipAirflow30(StarshipAirflow):
             self.session.rollback()
             raise e
 
-    def update_dag_version_id(self, dag_id: str, dag_version_id: str = None):
+    def update_dag_version_id(self, dag_id: str, dag_version_id: Optional[str] = None):
         """
         Update dag_version_id(FK) for task instances AND dag runs that have NULL values.
         Update created_dag_version_id on dag_run records so the UI can properly display them.

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -6,6 +6,7 @@ import os
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import Subquery
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple, TypedDict, Union
@@ -397,6 +398,17 @@ def task_log_path(
     # We also want to have access to the path only for logging purposes.
     path = os.path.join(base_folder, *path_components)
     return path, conn_id
+
+
+def run_id_sub_query(dag_id: str, limit: str, offset: str, session: Session) -> Subquery:
+    """Utility function to generate sub-queries for paging over run Ids."""
+    from airflow.models import DagRun
+    from sqlalchemy import desc
+
+    query = session.query(DagRun.run_id).filter(DagRun.dag_id == dag_id).order_by(desc(DagRun.start_date)).limit(limit)
+    if offset:
+        query = query.offset(offset)
+    return query.subquery()
 
 
 class BaseStarshipAirflow:

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -400,7 +400,7 @@ def task_log_path(
     return path, conn_id
 
 
-def run_id_sub_query(dag_id: str, limit: str, offset: str, session: Session) -> Subquery:
+def run_id_sub_query(dag_id: str, limit: int, offset: int, session: Session) -> Subquery:
     """Utility function to generate sub-queries for paging over run Ids."""
     from airflow.models import DagRun
     from sqlalchemy import desc

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -172,7 +172,7 @@ def import_from_qualname(qualname: str) -> "Tuple[str, Any]":
     )
 
 
-def get_kwargs_fn(request_method: str, args: dict, json: dict, attrs: dict):
+def get_kwargs_fn(request_method: str, args: dict, json: dict, attrs: dict, body: Union[bytes, None] = None):
     """
     Walks the attrs dict
     - if the request method is in the "methods" list we call get_from_request
@@ -184,6 +184,7 @@ def get_kwargs_fn(request_method: str, args: dict, json: dict, attrs: dict):
     :param args: request.args
     :param json: request.json
     :param attrs: the attrs to get from the request - e.g. StarshipAirflow27.dag_attrs()
+    :param body: the request body to pass as a keyword argument if provided
 
     >>> get_kwargs_fn(
     ...     "POST",
@@ -210,6 +211,10 @@ def get_kwargs_fn(request_method: str, args: dict, json: dict, attrs: dict):
                 val = get_from_request(args, json, attr, required=is_required)
                 if val is not None:
                     kwargs[key] = val
+    # This is a work-around to make the request body accessible to the Starship compatibility
+    # layer in Airflow 3.
+    if body is not None:
+        kwargs["body"] = body
     return kwargs
 
 
@@ -343,21 +348,20 @@ def normalize_for_comparison(data: "Union[Dict, List]") -> "Union[Dict, List]":
     return data
 
 
-def task_log_path(
+def task_log_base_path(
     *,
-    dag_id,
-    run_id,
-    task_id,
-    map_index,
-    try_number,
+    dag_id: str,
+    run_id: str,
+    task_id: str,
+    map_index: "Union[str, int]",
     **_,
-) -> "Tuple[str, str | None]":
-    """Get the path to the task log file and the connection ID for remote storage."""
+) -> "Tuple[str, Union[str, None]]":
+    """Get the base path to the task log files for all attempts and the corresponding connection ID for remote storage."""
     astronomer_environment = os.getenv("ASTRONOMER_ENVIRONMENT")
 
     if astronomer_environment == "cloud":
         # Astro Hosted
-        base_folder = os.getenv("AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER")
+        base_folder = os.environ["AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER"]
         conn_id = None
         for key in [
             "AIRFLOW_CONN_ASTRO_GCS_LOGGING",
@@ -377,26 +381,22 @@ def task_log_path(
     else:
         raise ConflictError("Task logs are only supported on Astronomer environments.")
 
-    path_components = (
-        [
-            f"dag_id={dag_id}",
-            f"run_id={run_id}",
-            f"task_id={task_id}",
-            f"attempt={try_number}.log",
-        ]
-        if map_index == "-1"
-        else [
-            f"dag_id={dag_id}",
-            f"run_id={run_id}",
-            f"task_id={task_id}",
-            f"map_index={map_index}",
-            f"attempt={try_number}.log",
-        ]
-    )
+    path_components = [
+        base_folder,
+        f"dag_id={dag_id}",
+        f"run_id={run_id}",
+        f"task_id={task_id}",
+    ]
+
+    if map_index is not None and int(map_index) >= 0:
+        path_components += [f"map_index={map_index}"]
+
     # ObjectStoragePath could be used to build the full path, but there seems to be a problem
     # where the connection ID duplicates with each path segment.
     # We also want to have access to the path only for logging purposes.
-    path = os.path.join(base_folder, *path_components)
+    # Furthermore, the import path for ObjectStoragePath depends on the Airflow version.
+    # Keeping ObjectStoragePath out here keeps the function Airflow version agnostic.
+    path = os.path.join(*path_components)
     return path, conn_id
 
 
@@ -538,13 +538,13 @@ class BaseStarshipAirflow:
     def task_log_attrs(cls) -> "Dict[str, AttrDesc]":
         raise NotImplementedError("Subclasses must implement task_log_attrs method")
 
-    def get_task_log(self):
+    def get_task_log(self, filename: str, **kwargs):
         raise NotImplementedError("Subclasses must implement get_task_log method")
 
-    def set_task_log(self, **kwargs):
+    def set_task_log(self, filename: str, **kwargs):
         raise NotImplementedError("Subclasses must implement set_task_log method")
 
-    def delete_task_log(self, **kwargs):
+    def delete_task_log(self, filename: str, **kwargs):
         raise NotImplementedError("Subclasses must implement delete_task_log method")
 
     @classmethod

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import Subquery
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple, TypedDict, Union
 
     class AttrDesc(TypedDict):
-        attr: str
+        attr: Optional[str]
         """the name in the ORM, likely the same as the key"""
 
         methods: List[Tuple[str, bool]]
@@ -67,7 +67,7 @@ def get_json_or_clean_str(o: str) -> Union[List[Any], Dict[Any, Any], Any]:
         return o.strip()
 
 
-def clean_airflow_report_output(log_string: str) -> Union[dict, str]:
+def clean_airflow_report_output(log_string: str) -> Union[List[Any], Dict[Any, Any], Any]:
     r"""For Aeroscope - Look for the magic string from the Airflow report and then decode the base64 and convert to json
     Or return output as a list, trimmed and split on newlines
     >>> clean_airflow_report_output("INFO 123 - xyz - abc\n\n\nERROR - 1234\n%%%%%%%\naGVsbG8gd29ybGQ=")
@@ -101,7 +101,7 @@ def telescope(
     *,
     organization: str,
     presigned_url: Union[str, None] = None,
-) -> Union[Dict, str]:
+) -> Union[Dict, str, Tuple[Union[str, bytes], int]]:
     import io
     import runpy
     from contextlib import redirect_stderr, redirect_stdout

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -101,7 +101,7 @@ def telescope(
     *,
     organization: str,
     presigned_url: Union[str, None] = None,
-) -> Union[Dict, str, Tuple[Union[str, bytes], int]]:
+) -> "Union[Dict, str, Tuple[Union[str, bytes], int]]":
     import io
     import runpy
     from contextlib import redirect_stderr, redirect_stdout

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -535,6 +535,13 @@ class BaseStarshipAirflow:
         raise NotImplementedError("Subclasses must implement set_task_instance_history method")
 
     @classmethod
+    def task_log_files_attrs(cls) -> "Dict[str, AttrDesc]":
+        raise NotImplementedError("Subclasses must implement task_log_files_attrs method")
+
+    def get_task_log_files(self, dag_id: str, offset: int = 0, limit: int = 10):
+        raise NotImplementedError("Subclasses must implement get_task_log_files method")
+
+    @classmethod
     def task_log_attrs(cls) -> "Dict[str, AttrDesc]":
         raise NotImplementedError("Subclasses must implement task_log_attrs method")
 

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -6,10 +6,11 @@ import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from sqlalchemy.orm import Session
-from sqlalchemy.sql.expression import Subquery
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple, TypedDict, Union
+
+    from sqlalchemy.sql.expression import Subquery
 
     class AttrDesc(TypedDict):
         attr: Optional[str]
@@ -400,7 +401,7 @@ def task_log_base_path(
     return path, conn_id
 
 
-def run_id_sub_query(dag_id: str, limit: int, offset: int, session: Session) -> Subquery:
+def run_id_sub_query(dag_id: str, limit: int, offset: int, session: Session) -> "Subquery":
     """Utility function to generate sub-queries for paging over run Ids."""
     from airflow.models import DagRun
     from sqlalchemy import desc

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -342,6 +342,63 @@ def normalize_for_comparison(data: "Union[Dict, List]") -> "Union[Dict, List]":
     return data
 
 
+def task_log_path(
+    *,
+    dag_id,
+    run_id,
+    task_id,
+    map_index,
+    try_number,
+    **_,
+) -> "Tuple[str, str | None]":
+    """Get the path to the task log file and the connection ID for remote storage."""
+    astronomer_environment = os.getenv("ASTRONOMER_ENVIRONMENT")
+
+    if astronomer_environment == "cloud":
+        # Astro Hosted
+        base_folder = os.getenv("AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER")
+        conn_id = None
+        for key in [
+            "AIRFLOW_CONN_ASTRO_GCS_LOGGING",
+            "AIRFLOW_CONN_ASTRO_AZURE_LOGS",
+            "AIRFLOW_CONN_ASTRO_S3_LOGGING",
+        ]:
+            conn_id = os.getenv(key)
+            if conn_id is not None:
+                break
+
+        if conn_id is None:
+            raise ConflictError("No remote logging connection found.")
+    elif astronomer_environment == "local":
+        # Local astro dev environment
+        base_folder = "/usr/local/airflow/logs"
+        conn_id = None
+    else:
+        raise ConflictError("Task logs are only supported on Astronomer environments.")
+
+    path_components = (
+        [
+            f"dag_id={dag_id}",
+            f"run_id={run_id}",
+            f"task_id={task_id}",
+            f"attempt={try_number}.log",
+        ]
+        if map_index == "-1"
+        else [
+            f"dag_id={dag_id}",
+            f"run_id={run_id}",
+            f"task_id={task_id}",
+            f"map_index={map_index}",
+            f"attempt={try_number}.log",
+        ]
+    )
+    # ObjectStoragePath could be used to build the full path, but there seems to be a problem
+    # where the connection ID duplicates with each path segment.
+    # We also want to have access to the path only for logging purposes.
+    path = os.path.join(base_folder, *path_components)
+    return path, conn_id
+
+
 class BaseStarshipAirflow:
     """Base class for all Starship Airflow compatibility layers.
 

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -498,17 +498,17 @@ class BaseStarshipAirflow:
     def get_dags(self):
         raise NotImplementedError("Subclasses must implement get_dags method")
 
-    def set_dag_is_paused(self, **kwargs):
+    def set_dag_is_paused(self, dag_id: str, is_paused: bool):
         raise NotImplementedError("Subclasses must implement set_dag_is_paused method")
 
     @classmethod
     def dag_runs_attrs(cls) -> "Dict[str, AttrDesc]":
         raise NotImplementedError("Subclasses must implement dag_runs_attrs method")
 
-    def get_dag_runs(self):
+    def get_dag_runs(self, dag_id: str, offset: int = 0, limit: int = 10) -> dict:
         raise NotImplementedError("Subclasses must implement get_dag_runs method")
 
-    def set_dag_runs(self, **kwargs):
+    def set_dag_runs(self, dag_runs: list):
         raise NotImplementedError("Subclasses must implement set_dag_runs method")
 
     def delete_dag_runs(self, **kwargs):
@@ -518,20 +518,20 @@ class BaseStarshipAirflow:
     def task_instances_attrs(cls) -> "Dict[str, AttrDesc]":
         raise NotImplementedError("Subclasses must implement task_instances_attrs method")
 
-    def get_task_instances(self):
+    def get_task_instances(self, dag_id: str, offset: int = 0, limit: int = 10):
         raise NotImplementedError("Subclasses must implement get_task_instances method")
 
-    def set_task_instances(self, **kwargs):
+    def set_task_instances(self, task_instances: list):
         raise NotImplementedError("Subclasses must implement set_task_instances method")
 
     @classmethod
     def task_instance_history_attrs(cls) -> "Dict[str, AttrDesc]":
         raise NotImplementedError("Subclasses must implement task_instance_history_attrs method")
 
-    def get_task_instance_history(self):
+    def get_task_instance_history(self, dag_id: str, offset: int = 0, limit: int = 10):
         raise NotImplementedError("Subclasses must implement get_task_instance_history method")
 
-    def set_task_instance_history(self, **kwargs):
+    def set_task_instance_history(self, task_instances: list):
         raise NotImplementedError("Subclasses must implement set_task_instance_history method")
 
     @classmethod

--- a/dev3/justfile
+++ b/dev3/justfile
@@ -3,7 +3,7 @@ RUNTIME_VERSION := "3.1-12"
 default:
     @just --list
 
-# build the frontend assets for the webserver
+# build the frontend assets for the api-server
 _build-frontend:
     @just ../build-frontend
 
@@ -19,9 +19,9 @@ _build-image-remote: _build-wheel
 _build-wheel:
     @just ../build
 
-# run `astro dev bash [ARGS]` with the webserver pre-selected
+# run `astro dev bash [ARGS]` with the api-server pre-selected
 bash *ARGS:
-    @astro dev bash --webserver {{ ARGS }}
+    @astro dev bash --api-server {{ ARGS }}
 
 # run `astro dev deploy [ARGS]` with image suitable for deployments in astro
 deploy *ARGS: _build-image-remote
@@ -31,15 +31,15 @@ deploy *ARGS: _build-image-remote
 kill:
     @astro dev kill
 
-# run `astro dev logs [ARGS]` with the webserver pre-selected
+# run `astro dev logs [ARGS]` with the api-server pre-selected
 logs *ARGS:
-    @astro dev logs --webserver {{ ARGS }}
+    @astro dev logs --api-server {{ ARGS }}
 
 # run `astro dev ps`
 ps:
     @astro dev ps
 
-# restart local webserver with updated frontend assets and plugin code
+# restart local api-server with updated frontend assets and plugin code
 reload: _build-frontend
     @docker restart $(docker container ls --filter name=api-server --format="{{{{.ID}}")
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -578,9 +578,59 @@ Get and set TaskInstanceHistory records.
 | trigger_timeout          | >2.1    | date | 1970-01-01T00:00:00+00:00         |
 | executor_config          |         | str  |                                   |
 
+## Task Log Files
+
+Get a list of task log files.
+
+This endpoint allows to page over all task log files and then use the task log API for each file individually.
+
+!!! danger "Experimental"
+    This feature is considered experimental and subject to change.
+
+**Requirements:**
+
+- Airflow 2.8+
+- Astro hosted deployments or local astro dev environment
+
+---
+
+### `GET /api/starship/task_log_files`
+
+**Parameters:** Args
+
+| Field (*=Required)       | Version | Type               | Example                              |
+|--------------------------|---------|--------------------|--------------------------------------|
+| dag_id*                  |         | str                | dag_0                                |
+| limit                    |         | int                | 10                                   |
+| offset                   |         | int                | 0                                    |
+
+**Response**:
+
+```json
+{
+  "task_log_files": [
+    {
+      "dag_id": "example_log",
+      "run_id": "scheduled__2026-03-10T00:00:00+00:00",
+      "task_id": "run",
+      "map_index": -1,
+      "filename": "attempt=1.log"
+    },
+    {
+      "dag_id": "example_log",
+      "run_id": "scheduled__2026-03-10T00:00:00+00:00",
+      "task_id": "run",
+      "map_index": -1,
+      "filename": "attempt=1.log.123"
+    }
+  ],
+  "dag_run_count": 1
+}
+```
+
 ## Task Log
 
-Get, set or delete task logs.
+Get, set or delete individual task log files.
 
 !!! danger "Experimental"
     This feature is considered experimental and subject to change.

--- a/docs/api.md
+++ b/docs/api.md
@@ -602,7 +602,7 @@ Get, set or delete task logs.
 | run_id*                  |         | str                | scheduled__2025-06-30T20:00:00+00:00 |
 | task_id*                 |         | str                | task_0                               |
 | map_index*               |         | int                | -1                                   |
-| try_number*              |         | int                | 1                                    |
+| filename*                |         | int                | attempt=1.log                        |
 | block_size               |         | int                | 1048576                              |
 
 **Response**:
@@ -623,7 +623,7 @@ Get, set or delete task logs.
 | run_id*                  |         | str                | scheduled__2025-06-30T20:00:00+00:00 |
 | task_id*                 |         | str                | task_0                               |
 | map_index*               |         | int                | -1                                   |
-| try_number*              |         | int                | 1                                    |
+| filename*                |         | int                | attempt=1.log                        |
 | block_size               |         | int                | 1048576                              |
 
 **Request**:
@@ -646,7 +646,7 @@ Get, set or delete task logs.
 | run_id*                  |         | str                | scheduled__2025-06-30T20:00:00+00:00 |
 | task_id*                 |         | str                | task_0                               |
 | map_index*               |         | int                | -1                                   |
-| try_number*              |         | int                | 1                                    |
+| filename*                |         | int                | attempt=1.log                        |
 
 **Response:** None
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,23 +60,23 @@ pip install astronomer-starship
 The following Airflow features are supported by the current version of Starship when running
 on the corresponding minimum Airflow version.
 
-| Feature | Minimum Airflow Version | Supported |
-| --- | --- | --- |
-| Connections | 2.0 | ✅ |
-| Dag runs | 2.0 | ✅ |
-| Environment variables | 2.0 | ✅ |
-| Pools | 2.0 | ✅ |
-| Task instances | 2.0 | ✅ |
-| Variables | 2.0 | ✅ |
-| Task Logs | 2.0 | ❌ |
-| XComs | 2.0 | ❌ |
-| Task instance history | 2.10 | ✅ |
-| Assets | 3.0 | ❌ |
-| Backfills | 3.0 | ❌ |
-| Dag versions | 3.0 | ❌ |
-| Task instance notes | 3.0 | ❌ |
-| HITL | 3.1 | ❌ |
-| Teams | 3.1 | ❌ |
+| Feature | Minimum Airflow Version | Supported | Notes |
+| --- | --- | --- | --- |
+| Connections | 2.0 | ✅ | |
+| Dag runs | 2.0 | ✅ | |
+| Environment variables | 2.0 | ✅ | |
+| Pools | 2.0 | ✅ | |
+| Task instances | 2.0 | ✅ | |
+| Variables | 2.0 | ✅ | |
+| Task Logs | 2.8 | ⚠️ (Experimental) | API & Astro only |
+| XComs | 2.0 | ❌ | |
+| Task instance history | 2.10 | ✅ | |
+| Assets | 3.0 | ❌ | |
+| Backfills | 3.0 | ❌ | |
+| Dag versions | 3.0 | ❌ | |
+| Task instance notes | 3.0 | ❌ | |
+| HITL | 3.1 | ❌ | |
+| Teams | 3.1 | ❌ | |
 
 ## Security Notice
 


### PR DESCRIPTION
* change task log API to work on individual files directly instead of try-numbers
* make task log API work in Airflow 3
* add task log files API for paging through task log files

Breaking: There are changes to the experimental task log API which are not compatible with how the API has been used in earlier version.