### PR TITLE
fix: add API authorization to require admin access

### DIFF
--- a/astronomer_starship/__init__.py
+++ b/astronomer_starship/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.8.5"
+__version__ = "2.8.6"
 
 
 def get_provider_info():

--- a/astronomer_starship/_af2/starship_api.py
+++ b/astronomer_starship/_af2/starship_api.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 # restrict access to users with access to the Airflow configuration, which is more or less equivalent to admin access.
-REQUIRES_ADMIN = auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_CONFIG)])
+requires_config_read = auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_CONFIG)])
 
 
 def starship_route(  # noqa: C901
@@ -109,7 +109,7 @@ class StarshipApi(BaseView):
     route_base = "/api/starship"
     default_view = "health"
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/health", methods=["GET"])
     @csrf.exempt
     def health(self) -> str:
@@ -118,7 +118,7 @@ class StarshipApi(BaseView):
 
         return starship_route(get=ok)
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/telescope", methods=["GET"])
     @csrf.exempt
     def telescope(self):
@@ -127,28 +127,28 @@ class StarshipApi(BaseView):
             presigned_url=request.args.get("presigned_url", None),
         )
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/airflow_version", methods=["GET"])
     @csrf.exempt
     def airflow_version(self) -> str:
         starship_compat = StarshipCompatabilityLayer()
         return starship_route(get=starship_compat.get_airflow_version)
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/info", methods=["GET"])
     @csrf.exempt
     def info(self) -> str:
         starship_compat = StarshipCompatabilityLayer()
         return starship_route(get=starship_compat.get_info)
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/env_vars", methods=["GET"])
     @csrf.exempt
     def env_vars(self):
         starship_compat = StarshipCompatabilityLayer()
         return starship_route(get=starship_compat.get_env_vars)
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/pools", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def pools(self):
@@ -160,7 +160,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.pool_attrs()),
         )
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/variables", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def variables(self):
@@ -172,7 +172,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.variable_attrs()),
         )
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/connections", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def connections(self):
@@ -184,7 +184,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.connection_attrs()),
         )
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/dags", methods=["GET", "PATCH"])
     @csrf.exempt
     def dags(self):
@@ -195,7 +195,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.dag_attrs()),
         )
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/dag_runs", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def dag_runs(self):
@@ -207,7 +207,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.dag_runs_attrs()),
         )
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/task_instances", methods=["GET", "POST"])
     @csrf.exempt
     def task_instances(self):
@@ -218,7 +218,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_instances_attrs()),
         )
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/task_instance_history", methods=["GET", "POST"])
     @csrf.exempt
     def task_instance_history(self):
@@ -229,7 +229,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_instance_history_attrs()),
         )
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/task_log", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def task_logs(self):
@@ -241,7 +241,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_log_attrs()),
         )
 
-    @REQUIRES_ADMIN
+    @requires_config_read
     @expose("/xcom", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def xcom(self):

--- a/astronomer_starship/_af2/starship_api.py
+++ b/astronomer_starship/_af2/starship_api.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 
 import flask
 from airflow.plugins_manager import AirflowPlugin
+from airflow.security import permissions
+from airflow.www import auth
 from airflow.www.app import csrf
 from flask import Blueprint, Response, jsonify, request
 from flask_appbuilder import BaseView, expose
@@ -16,6 +18,10 @@ from astronomer_starship.common import HttpError, get_kwargs_fn, telescope
 
 if TYPE_CHECKING:
     from typing import Callable
+
+
+# restrict access to users with access to the Airflow configuration, which is more or less equivalent to admin access.
+REQUIRES_ADMIN = auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_CONFIG)])
 
 
 def starship_route(  # noqa: C901
@@ -103,6 +109,7 @@ class StarshipApi(BaseView):
     route_base = "/api/starship"
     default_view = "health"
 
+    @REQUIRES_ADMIN
     @expose("/health", methods=["GET"])
     @csrf.exempt
     def health(self) -> str:
@@ -111,6 +118,7 @@ class StarshipApi(BaseView):
 
         return starship_route(get=ok)
 
+    @REQUIRES_ADMIN
     @expose("/telescope", methods=["GET"])
     @csrf.exempt
     def telescope(self):
@@ -119,26 +127,28 @@ class StarshipApi(BaseView):
             presigned_url=request.args.get("presigned_url", None),
         )
 
+    @REQUIRES_ADMIN
     @expose("/airflow_version", methods=["GET"])
     @csrf.exempt
     def airflow_version(self) -> str:
         starship_compat = StarshipCompatabilityLayer()
         return starship_route(get=starship_compat.get_airflow_version)
 
+    @REQUIRES_ADMIN
     @expose("/info", methods=["GET"])
     @csrf.exempt
     def info(self) -> str:
         starship_compat = StarshipCompatabilityLayer()
         return starship_route(get=starship_compat.get_info)
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_CONFIG)])
+    @REQUIRES_ADMIN
     @expose("/env_vars", methods=["GET"])
     @csrf.exempt
     def env_vars(self):
         starship_compat = StarshipCompatabilityLayer()
         return starship_route(get=starship_compat.get_env_vars)
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_POOL)])
+    @REQUIRES_ADMIN
     @expose("/pools", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def pools(self):
@@ -150,7 +160,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.pool_attrs()),
         )
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_VARIABLE)])
+    @REQUIRES_ADMIN
     @expose("/variables", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def variables(self):
@@ -162,7 +172,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.variable_attrs()),
         )
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_CONNECTION)])
+    @REQUIRES_ADMIN
     @expose("/connections", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def connections(self):
@@ -174,7 +184,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.connection_attrs()),
         )
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
+    @REQUIRES_ADMIN
     @expose("/dags", methods=["GET", "PATCH"])
     @csrf.exempt
     def dags(self):
@@ -185,7 +195,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.dag_attrs()),
         )
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN)])
+    @REQUIRES_ADMIN
     @expose("/dag_runs", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def dag_runs(self):
@@ -197,7 +207,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.dag_runs_attrs()),
         )
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE)])
+    @REQUIRES_ADMIN
     @expose("/task_instances", methods=["GET", "POST"])
     @csrf.exempt
     def task_instances(self):
@@ -208,7 +218,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_instances_attrs()),
         )
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE_HISTORY)])
+    @REQUIRES_ADMIN
     @expose("/task_instance_history", methods=["GET", "POST"])
     @csrf.exempt
     def task_instance_history(self):
@@ -219,7 +229,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_instance_history_attrs()),
         )
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE)])
+    @REQUIRES_ADMIN
     @expose("/task_log", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def task_logs(self):
@@ -231,7 +241,7 @@ class StarshipApi(BaseView):
             kwargs_fn=partial(get_kwargs_fn, attrs=starship_compat.task_log_attrs()),
         )
 
-    # @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE)])
+    @REQUIRES_ADMIN
     @expose("/xcom", methods=["GET", "POST", "DELETE"])
     @csrf.exempt
     def xcom(self):

--- a/astronomer_starship/_af3/starship_api.py
+++ b/astronomer_starship/_af3/starship_api.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Annotated
 
 from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.core_api.security import requires_access_configuration
 from airflow.plugins_manager import AirflowPlugin
 from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -127,7 +128,11 @@ async def starship_compat() -> StarshipAirflow:
     return StarshipCompatabilityLayer()
 
 
-router = AirflowRouter(tags=["Starship"])
+router = AirflowRouter(
+    tags=["Starship"],
+    # restrict access to users with access to the Airflow configuration, which is more or less equivalent to admin access.
+    dependencies=[Depends(requires_access_configuration("GET"))],
+)
 
 
 class StarshipApi(FastAPI):

--- a/dev2/Dockerfile
+++ b/dev2/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUNTIME_VERSION=13.4.0
+ARG RUNTIME_VERSION=13.7.0
 FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:${RUNTIME_VERSION}-base
 
 WORKDIR /usr/local/airflow

--- a/dev2/Dockerfile.local
+++ b/dev2/Dockerfile.local
@@ -1,4 +1,4 @@
-ARG RUNTIME_VERSION=13.4.0
+ARG RUNTIME_VERSION=13.7.0
 FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:${RUNTIME_VERSION}-base
 
 WORKDIR /usr/local/airflow

--- a/dev2/justfile
+++ b/dev2/justfile
@@ -1,4 +1,4 @@
-RUNTIME_VERSION := "13.4.0"
+RUNTIME_VERSION := "13.7.0"
 
 default:
     @just --list

--- a/dev3/Dockerfile
+++ b/dev3/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUNTIME_VERSION=3.1-12
+ARG RUNTIME_VERSION=3.1-15
 FROM astrocrpublic.azurecr.io/runtime:${RUNTIME_VERSION}-base
 
 WORKDIR /usr/local/airflow

--- a/dev3/Dockerfile.local
+++ b/dev3/Dockerfile.local
@@ -1,4 +1,4 @@
-ARG RUNTIME_VERSION=3.1-12
+ARG RUNTIME_VERSION=3.1-15
 FROM astrocrpublic.azurecr.io/runtime:${RUNTIME_VERSION}-base
 
 WORKDIR /usr/local/airflow

--- a/dev3/justfile
+++ b/dev3/justfile
@@ -54,3 +54,9 @@ start *ARGS: _build-frontend _build-image-local
 # run `astro dev stop`
 stop:
     @astro dev stop
+
+# make authenticated curl request to dev server with path and additional curl args
+curl path *ARGS:
+    #!/bin/bash
+    TOKEN=$(curl -s -X POST http://dev3.localhost:6563/auth/token -H "Content-Type: application/json" -d '{"username": "admin", "password": "admin"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")  # pragma: allowlist secret
+    curl http://dev3.localhost:6563/{{path}} -H "Authorization: Bearer $TOKEN" {{ARGS}}

--- a/dev3/justfile
+++ b/dev3/justfile
@@ -1,4 +1,4 @@
-RUNTIME_VERSION := "3.1-12"
+RUNTIME_VERSION := "3.1-15"
 
 default:
     @just --list


### PR DESCRIPTION
Enhance security by restricting Starship API endpoints to admin users, utilizing Airflow's authentication manager. Update development runtime versions and provide examples for authenticated curl requests to the dev server. Bump version to 2.8.6.