### PR TITLE
Implement version bumping and release tagging with Commitizen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,4 +76,4 @@ The React app talks to the *target* Airflow via a `/proxy` endpoint on the *sour
 
 - `requires-python = ">=3.6"` (the package still supports the very old Pythons that older Airflow 2 deployments ran on). Ruff is pinned to `target-version = "py37"` accordingly. Don't use 3.8+ syntax (walrus, f-string `=`, etc.) in shipped code.
 - Starship only supports Airflow up to 3.1 right now (`apache-airflow<3.2` in dev extra).
-- Releases: tag `v<__version__>` on `main`, push tag → CI builds, uploads to TestPyPI, then a manual GitHub release approval publishes to PyPI. `__version__` lives in `astronomer_starship/__init__.py`.
+- Releases: a release manager runs `just release MAJOR|MINOR|PATCH` from an up-to-date `main` branch. This uses [commitizen](https://commitizen-tools.github.io/commitizen/) to bump `__version__` in `astronomer_starship/__init__.py`, create a bump commit and a `v<version>` tag, and push both to GitHub. CI then builds and publishes the package directly to PyPI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,18 +41,17 @@ the Starship API Routes
 3. Push up to GitHub (running pre-commit)
 4. Create a PR, get approval
 5. Merge the PR to `main`
-6. On `main`: Create a tag
+6. Do any manual or integration testing
+7. A release manager (with push permissions) runs:
 
     ```shell
-    VERSION="v$(python -c 'import astronomer_starship; print(astronomer_starship.__version__)')"; git tag -d $VERSION; git tag $VERSION
+    just release PATCH   # or MINOR or MAJOR
     ```
 
-7. Do any manual or integration testing
-8. Push the tag to GitHub `git push origin --tag`, which will create
-   a `Draft` [release](https://github.com/astronomer/astronomer-starship/releases) and upload
-   to [test.pypi.org](https://test.pypi.org/project/astronomer-starship/) via CICD
-9. Approve the [release](https://github.com/astronomer/astronomer-starship/releases) on GitHub, which
-   will upload to [pypi.org](https://pypi.org/project/astronomer-starship/) via CICD
+    This uses [commitizen](https://commitizen-tools.github.io/commitizen/) to bump the version in
+    `astronomer_starship/__init__.py`, create a bump commit, tag it as `v<version>`, and push both
+    to GitHub. CI will then build and publish the package directly to [pypi.org](https://pypi.org/project/astronomer-starship/).
+    The recipe enforces that you are on `main` and up-to-date with `origin/main`.
 
 ### Versioning
 

--- a/justfile
+++ b/justfile
@@ -2,7 +2,6 @@
 set dotenv-load := true
 SRC_DIR := "astronomer_starship"
 DOCS_DIR := "docs"
-VERSION := `echo $(python -c 'from astronomer_starship import __version__; print(__version__)')`
 
 default:
     @just --choose
@@ -102,19 +101,10 @@ clean-frontend-install:
 # Clean everything
 clean: clean-backend-build clean-frontend-build clean-frontend-install
 
-# Tag as v$(<src>.__version__) and push to GH
-tag:
-    # Delete tag if it already exists
-    git tag -d v{{VERSION}} || true
-    # Tag and push
-    git tag v{{VERSION}}
-
-# Deploy the project
-deploy-tag: tag
-    git push origin v{{VERSION}}
-
-# Deploy the project
-deploy: deploy-tag
+# Bump the version, create a release commit and tag, and push (TYPE: MAJOR, MINOR, PATCH)
+release TYPE:
+    cz bump --increment {{TYPE}}
+    git push && git push --tags
 
 # Upload to TestPyPi for testing (note: you can only use each version once)
 upload-testpypi: clean install build

--- a/justfile
+++ b/justfile
@@ -103,6 +103,20 @@ clean: clean-backend-build clean-frontend-build clean-frontend-install
 
 # Bump the version, create a release commit and tag, and push (TYPE: MAJOR, MINOR, PATCH)
 release TYPE:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$current_branch" != "main" ]; then
+        echo "Error: releases must be made from the 'main' branch (currently on '$current_branch')"
+        exit 1
+    fi
+    git fetch origin main
+    local_sha=$(git rev-parse HEAD)
+    remote_sha=$(git rev-parse origin/main)
+    if [ "$local_sha" != "$remote_sha" ]; then
+        echo "Error: local 'main' is not up-to-date with 'origin/main'"
+        exit 1
+    fi
     cz bump --increment {{TYPE}}
     git push && git push --tags
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     # package
     "twine",
     "build",
+    "commitizen",
 
     # test
     "apache-airflow<3.2", # Starship only supports Airflow version up to 3.1 at the moment
@@ -140,3 +141,9 @@ addopts = [
     "--doctest-modules",
     "--doctest-continue-on-failure",
 ]
+
+[tool.commitizen]
+version = "2.8.6"
+version_files = ["astronomer_starship/__init__.py:__version__"]
+tag_format = "v$version"
+update_changelog_on_bump = false

--- a/tests/validation_test.py
+++ b/tests/validation_test.py
@@ -149,14 +149,3 @@ def test_docker_pytest(has_docker, docker_client, project_root, local_version):
             if test.exception():
                 raise test.exception()
 
-
-def test_version(local_version):
-    import requests
-
-    package = "astronomer-starship"
-
-    releases = requests.get(f"https://pypi.org/pypi/{package}/json").json()["releases"]
-    shipped_versions = []
-    [shipped_versions.append(version) for version, details in releases.items()]
-
-    assert local_version not in shipped_versions

--- a/tests/validation_test.py
+++ b/tests/validation_test.py
@@ -148,4 +148,3 @@ def test_docker_pytest(has_docker, docker_client, project_root, local_version):
             test: Future
             if test.exception():
                 raise test.exception()
-


### PR DESCRIPTION
## Summary

Replaces the manual version-tagging workflow with [Commitizen](https://commitizen-tools.github.io/commitizen/), giving release managers a single command to bump the version, commit, tag, and push.

## Changes

### Release workflow
- Added `just release TYPE` recipe (`TYPE`: `MAJOR`, `MINOR`, or `PATCH`) that:
  - Enforces the release is made from an up-to-date `main` branch
  - Uses `cz bump --increment TYPE` to update `__version__` in `astronomer_starship/__init__.py`, create a bump commit, and tag it as `v<version>`
  - Pushes the commit and tag to GitHub (CI then publishes directly to PyPI)
- Removed the old `tag`, `deploy-tag`, and `deploy` recipes from the `justfile`
- Removed the `VERSION` variable from the `justfile` (version is no longer read at recipe-invocation time)

### Dependencies
- Added `commitizen` to the `dev` extras in `pyproject.toml`
- Added `[tool.commitizen]` config pointing at `astronomer_starship/__init__.py` with `tag_format = "v$version"` and `update_changelog_on_bump = false`

### Tests
- Removed `test_version` from `tests/validation_test.py` — checking that the local version isn't already on PyPI is no longer needed since contributors don't manage version numbers

### Docs
- Updated `CLAUDE.md` and `CONTRIBUTING.md` to reflect the new release process