### PR TITLE
Update GitHub Actions for deployment and documentation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,13 +13,38 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.10'
           cache: 'pip'
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
       - run: just build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           skip-existing: true
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: softprops/action-gh-release@v3.0.0
+        with:
+          generate_release_notes: true
+
+  publish-docs:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - run: pip install -c constraints.txt '.[docs]'
+      - run: mkdocs gh-deploy --force

--- a/justfile
+++ b/justfile
@@ -199,14 +199,6 @@ update-secrets:
 serve-docs:
     mkdocs serve -w {{DOCS_DIR}} -w {{SRC_DIR}}
 
-# Build documentation locally (likely unnecessary)
-build-docs: clean
-    mkdocs build
-
-# Deploy the documentation to GitHub Pages
-deploy-docs UPSTREAM="origin": clean
-    mkdocs gh-deploy -r {{UPSTREAM}}
-
 # run just commands from the dev2 project for running the local version of Starship in Airflow 2
 dev2 *ARGS:
     @just dev2/{{ARGS}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,10 @@ dev = [
     "docker>=6",
 
     # docs
+    "astronomer-starship[docs]",
+]
+
+docs = [
     "mkdocs",
     "mkdocs-material",
     "mkdocstrings[python]",


### PR DESCRIPTION
## Changes

### GitHub Actions (`deploy.yaml`)
- **Updated all action versions** to their latest releases (`actions/checkout@v6.0.2`, `actions/setup-python@v6.2.0`, `extractions/setup-just@v4`, `pypa/gh-action-pypi-publish@v1.14.0`)
- **Added `release` job**: runs after PyPI publish succeeds; creates a GitHub release for the tag with auto-generated release notes (equivalent to the GitHub UI's "Generate release notes" button)
- **Added `publish-docs` job**: runs after the release is created; deploys updated docs to GitHub Pages via `mkdocs gh-deploy`

### Justfile
- Removed `build-docs` and `deploy-docs` recipes — docs deployment is now handled by CI on every release

### `pyproject.toml`
- Extracted docs dependencies (`mkdocs`, `mkdocs-material`, `mkdocstrings[python]`, `pygments`) into a new `docs` optional extra
- `dev` extra pulls in `docs` via `astronomer-starship[docs]` so local dev is unaffected

## Pipeline flow on tag push

```
publish (PyPI) → release (GitHub Release + auto notes) → publish-docs (gh-pages)
```