### PR TITLE
Accept non-Astro URLs as target

### DIFF
--- a/astronomer_starship/src/AppContext.jsx
+++ b/astronomer_starship/src/AppContext.jsx
@@ -50,7 +50,7 @@ function calculateIsSetupComplete(state, overrides = {}) {
 function reducer(state, action) {
   switch (action.type) {
     case 'set-url': {
-      const isValidUrl = !!(action.urlOrgPart && action.urlDeploymentPart);
+      const isValidUrl = !!action.isValid;
       return {
         ...state,
         isTouched: true,

--- a/astronomer_starship/src/component/UrlTokenForm.jsx
+++ b/astronomer_starship/src/component/UrlTokenForm.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import {
+  Box,
+  Code,
   Divider,
   FormControl,
   FormErrorMessage,
@@ -10,7 +12,9 @@ import {
   InputGroup,
   InputRightElement,
   Link,
+  Text,
   Tooltip,
+  VStack,
 } from '@chakra-ui/react';
 import { CheckIcon, ExternalLinkIcon, InfoIcon } from '@chakra-ui/icons';
 import { parseAirflowUrl, tokenUrlFromAirflowUrl } from '../util';
@@ -63,6 +67,31 @@ export default function UrlTokenForm({
         <FormHelperText fontSize="xs">Paste the full webserver URL of your target Airflow deployment</FormHelperText>
         <FormErrorMessage>Please enter a valid Airflow URL</FormErrorMessage>
       </FormControl>
+
+      {/* URL Format Guidance */}
+      <Box mt={3} p={3} bg="gray.50" borderRadius="md" borderWidth="1px" borderColor="gray.200">
+        <Text fontSize="xs" fontWeight="semibold" color="gray.600" mb={2}>
+          Supported URL Formats
+        </Text>
+        <VStack align="stretch" spacing={2}>
+          <Box>
+            <Text fontSize="2xs" color="gray.500" mb={0.5}>
+              Astro (Cloud)
+            </Text>
+            <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
+              https://claaabbbcccddd.astronomer.run/aabbccdd
+            </Code>
+          </Box>
+          <Box>
+            <Text fontSize="2xs" color="gray.500" mb={0.5}>
+              Astro Private Cloud (Software)
+            </Text>
+            <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
+              https://deployments.basedomain.com/release-name-1234/airflow
+            </Code>
+          </Box>
+        </VStack>
+      </Box>
 
       <Divider my={3} />
 

--- a/astronomer_starship/src/component/UrlTokenForm.jsx
+++ b/astronomer_starship/src/component/UrlTokenForm.jsx
@@ -44,6 +44,7 @@ export default function UrlTokenForm({
       targetUrl: parsed.isValid ? parsed.targetUrl : e.target.value,
       urlOrgPart: parsed.urlOrgPart,
       urlDeploymentPart: parsed.urlDeploymentPart,
+      isValid: parsed.isValid,
     });
   };
 

--- a/astronomer_starship/src/component/UrlTokenForm.jsx
+++ b/astronomer_starship/src/component/UrlTokenForm.jsx
@@ -71,7 +71,7 @@ export default function UrlTokenForm({
       {/* URL Format Guidance */}
       <Box mt={3} p={3} bg="gray.50" borderRadius="md" borderWidth="1px" borderColor="gray.200">
         <Text fontSize="xs" fontWeight="semibold" color="gray.600" mb={2}>
-          Supported URL Formats
+          Example URL Formats
         </Text>
         <VStack align="stretch" spacing={2}>
           <Box>
@@ -79,15 +79,45 @@ export default function UrlTokenForm({
               Astro (Cloud)
             </Text>
             <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
-              https://claaabbbcccddd.astronomer.run/aabbccdd
+              https://cxxxxxxxxxxxxxxxxxxxxxxxx.xx.astronomer.run/dxxxxxxx
             </Code>
           </Box>
           <Box>
             <Text fontSize="2xs" color="gray.500" mb={0.5}>
-              Astro Private Cloud (Software)
+              Astro Private Cloud
             </Text>
             <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
               https://deployments.basedomain.com/release-name-1234/airflow
+            </Code>
+          </Box>
+          <Box>
+            <Text fontSize="2xs" color="gray.500" mb={0.5}>
+              AWS MWAA (Amazon Managed Workflows for Apache Airflow)
+            </Text>
+            <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
+              https://c1a2b3c4-d5e6-7f8g-9h0i-1j2k3l4m5n6o.c10.us-east-1.airflow.amazonaws.com
+            </Code>
+            <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
+              https://c1a2b3c4-d5e6-7f8g-9h0i-1j2k3l4m5n6o-vpce.c10.us-east-1.airflow.amazonaws.com
+            </Code>
+          </Box>
+          <Box>
+            <Text fontSize="2xs" color="gray.500" mb={0.5}>
+              GCP Managed Service for Apache Airflow
+            </Text>
+            <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
+              https://example-dot-us-central1.composer.googleusercontent.com
+            </Code>
+            <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
+              https://example-tp.appspot.com
+            </Code>
+          </Box>
+          <Box>
+            <Text fontSize="2xs" color="gray.500" mb={0.5}>
+              Self-managed Apache Airflow
+            </Text>
+            <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
+              https://airflow.internal.mycompany.com
             </Code>
           </Box>
         </VStack>

--- a/astronomer_starship/src/component/UrlTokenForm.jsx
+++ b/astronomer_starship/src/component/UrlTokenForm.jsx
@@ -1,7 +1,5 @@
 import PropTypes from 'prop-types';
 import {
-  Box,
-  Code,
   Divider,
   FormControl,
   FormErrorMessage,
@@ -12,9 +10,7 @@ import {
   InputGroup,
   InputRightElement,
   Link,
-  Text,
   Tooltip,
-  VStack,
 } from '@chakra-ui/react';
 import { CheckIcon, ExternalLinkIcon, InfoIcon } from '@chakra-ui/icons';
 import { parseAirflowUrl, tokenUrlFromAirflowUrl } from '../util';
@@ -67,31 +63,6 @@ export default function UrlTokenForm({
         <FormHelperText fontSize="xs">Paste the full webserver URL of your target Airflow deployment</FormHelperText>
         <FormErrorMessage>Please enter a valid Airflow URL</FormErrorMessage>
       </FormControl>
-
-      {/* URL Format Guidance */}
-      <Box mt={3} p={3} bg="gray.50" borderRadius="md" borderWidth="1px" borderColor="gray.200">
-        <Text fontSize="xs" fontWeight="semibold" color="gray.600" mb={2}>
-          Supported URL Formats
-        </Text>
-        <VStack align="stretch" spacing={2}>
-          <Box>
-            <Text fontSize="2xs" color="gray.500" mb={0.5}>
-              Astro (Cloud)
-            </Text>
-            <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
-              https://claaabbbcccddd.astronomer.run/aabbccdd
-            </Code>
-          </Box>
-          <Box>
-            <Text fontSize="2xs" color="gray.500" mb={0.5}>
-              Astro Private Cloud (Software)
-            </Text>
-            <Code fontSize="2xs" px={2} py={1} borderRadius="sm" display="block">
-              https://deployments.basedomain.com/release-name-1234/airflow
-            </Code>
-          </Box>
-        </VStack>
-      </Box>
 
       <Divider my={3} />
 

--- a/astronomer_starship/src/util.js
+++ b/astronomer_starship/src/util.js
@@ -72,10 +72,12 @@ export function getTargetUrlFromParts(urlOrgPart, urlDeploymentPart, isAstro) {
 
 /**
  * Parses an Airflow webserver URL and extracts the relevant parts.
- * Supports both Astro and Software URL formats.
+ * Recognizes Astro and Software URL formats specifically; any other Airflow URL
+ * (self-hosted/OSS, or anything else) is still accepted as a valid, generic target.
  *
  * Astro format: https://{org}.astronomer.run/{deployment}[/home]
  * Software format: https://deployments.{basedomain}/{release-name}/airflow[/home]
+ * Anything else: accepted as-is (trailing /home and trailing slash stripped)
  *
  * @param {string} url - The full Airflow webserver URL
  * @returns {{ targetUrl: string, urlOrgPart: string, urlDeploymentPart: string,
@@ -142,6 +144,16 @@ export function parseAirflowUrl(url) {
         result.targetUrl = `https://deployments.${result.urlOrgPart}/${result.urlDeploymentPart}/airflow`;
         result.isValid = true;
       }
+    } else {
+      // Any other Airflow URL (self-hosted/OSS, or anything else) — accepted as-is, no shape
+      // check. `isAstro` is left at its existing default; env var migration / Houston lookup
+      // behavior for non-Astro/Software targets is unchanged.
+      let cleanPath = pathname.replace(/\/+$/, '');
+      if (cleanPath.endsWith('/home')) {
+        cleanPath = cleanPath.slice(0, -'/home'.length);
+      }
+      result.targetUrl = `${parsed.protocol}//${parsed.host}${cleanPath}`;
+      result.isValid = true;
     }
   } catch {
     // Invalid URL

--- a/astronomer_starship/tests/src/util.test.js
+++ b/astronomer_starship/tests/src/util.test.js
@@ -108,14 +108,32 @@ describe('parseAirflowUrl', () => {
       expect(result.isValid).toBe(false);
     });
 
-    test('returns invalid for malformed URL', () => {
+    test('accepts a bare hostname with no shape check', () => {
+      // After protocol-prepending this parses as `https://not-a-valid-url`, a syntactically
+      // valid (if unusual) URL — there's no Astro/Software shape requirement to reject it.
       const result = parseAirflowUrl('not-a-valid-url');
-      expect(result.isValid).toBe(false);
+      expect(result.isValid).toBe(true);
+      expect(result.targetUrl).toBe('https://not-a-valid-url');
+    });
+  });
+
+  describe('Generic / OSS Airflow URLs', () => {
+    test('accepts a plain self-hosted domain', () => {
+      const result = parseAirflowUrl('https://random-domain.com/some/path');
+      expect(result.isValid).toBe(true);
+      expect(result.targetUrl).toBe('https://random-domain.com/some/path');
     });
 
-    test('returns invalid for unknown URL format', () => {
-      const result = parseAirflowUrl('https://random-domain.com/some/path');
-      expect(result.isValid).toBe(false);
+    test('accepts a self-hosted domain and strips a trailing /home', () => {
+      const result = parseAirflowUrl('https://airflow.mycompany.com/home');
+      expect(result.isValid).toBe(true);
+      expect(result.targetUrl).toBe('https://airflow.mycompany.com');
+    });
+
+    test('accepts a local Airflow instance (e.g. Astro CLI) with a port', () => {
+      const result = parseAirflowUrl('http://localhost:8080');
+      expect(result.isValid).toBe(true);
+      expect(result.targetUrl).toBe('http://localhost:8080');
     });
   });
 });


### PR DESCRIPTION
We're currently limiting migration to Astro and APC targets. I suggest enabling any Airflow.

Used Claude.

URL limitation is also removed from the UI:
Before:
<img width="557" height="436" alt="image" src="https://github.com/user-attachments/assets/3286f067-6a46-4b82-a41e-0dc734a37a5f" />

After:
<img width="623" height="612" alt="image" src="https://github.com/user-attachments/assets/4dca4b45-6ebe-43cd-835e-f026ab0d4897" />

