### PR TITLE
Strip dag_run log_template_id during AF3 migrations

### DIFF
--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -987,9 +987,11 @@ class StarshipAirflow30(StarshipAirflow):
             if "id" in item and table_name not in ["task_instance", "task_instance_history"]:
                 del item["id"]
 
-            # Strip FK fields that reference source-specific UUIDs
+            # Strip FK fields that reference source-specific metadata rows
             item.pop("dag_version_id", None)
             item.pop("created_dag_version_id", None)
+            if table_name == "dag_run":
+                item.pop("log_template_id", None)
 
             if "executor_config" in item:
                 # Drop executor_config, because its original type may have gotten lost

--- a/tests/test_af3_insert_sanitization.py
+++ b/tests/test_af3_insert_sanitization.py
@@ -1,0 +1,89 @@
+from astronomer_starship._af3.starship_compatability import StarshipAirflow31
+
+
+class FakeColumn:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeTable:
+    columns = [
+        FakeColumn("dag_id"),
+        FakeColumn("run_id"),
+        FakeColumn("log_template_id"),
+        FakeColumn("dag_version_id"),
+        FakeColumn("created_dag_version_id"),
+    ]
+
+
+class FakeMetaData:
+    def __init__(self, bind):
+        self.tables = {}
+
+    def reflect(self, engine, only):
+        self.tables[only[0]] = FakeTable()
+
+
+class FakeInsert:
+    def __init__(self, table):
+        self.table = table
+        self.items = None
+        self.conflict_target = None
+
+    def values(self, items):
+        self.items = items
+        return self
+
+    def on_conflict_do_nothing(self, index_elements=None):
+        self.conflict_target = index_elements
+        return self
+
+
+class FakeSession:
+    def __init__(self):
+        self.statement = None
+        self.committed = False
+
+    def get_bind(self):
+        return object()
+
+    def execute(self, statement):
+        self.statement = statement
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        raise AssertionError("rollback should not be called")
+
+
+def test_dag_run_direct_insert_strips_source_log_template_id(monkeypatch):
+    import sqlalchemy
+    import sqlalchemy.dialects.postgresql
+
+    fake_session = FakeSession()
+    starship = StarshipAirflow31()
+    starship._session = fake_session
+
+    monkeypatch.setattr(sqlalchemy, "MetaData", FakeMetaData)
+    monkeypatch.setattr(sqlalchemy.dialects.postgresql, "insert", FakeInsert)
+
+    items = [
+        {
+            "dag_id": "example_dag",
+            "run_id": "scheduled__2026-08-01T00:00:00+00:00",
+            "log_template_id": 3,
+            "dag_version_id": "source-task-version-id",
+            "created_dag_version_id": "source-created-version-id",
+        }
+    ]
+
+    result = starship.insert_directly("dag_run", items)
+
+    inserted = fake_session.statement.items[0]
+    assert "log_template_id" not in inserted
+    assert "dag_version_id" not in inserted
+    assert "created_dag_version_id" not in inserted
+    assert fake_session.statement.conflict_target == ["dag_id", "run_id"]
+    assert fake_session.committed is True
+    assert result == [{"dag_id": "example_dag", "run_id": "scheduled__2026-08-01T00:00:00+00:00"}]


### PR DESCRIPTION
## Summary

- Strip `log_template_id` from AF3 `dag_run` direct inserts because it is a source deployment-local metadata FK.
- Keep existing cleanup for source-specific DAG version IDs.
- Add a focused unit test proving `log_template_id` is removed before the insert payload is sent to SQLAlchemy, even when the target table has that column.

Closes #179

## Validation

- `pytest -c /Users/varaprasadregani/repos/starship/pyproject.toml /Users/varaprasadregani/repos/starship/tests/test_af3_insert_sanitization.py` — passed.
- `pytest -c /Users/varaprasadregani/repos/starship/pyproject.toml /Users/varaprasadregani/repos/starship/tests --ignore=/Users/varaprasadregani/repos/starship/tests/validation_test.py` — passed: 1 passed, 15 skipped.
- Full backend suite with `tests/validation_test.py` included could not complete because Docker is not running/reachable in this environment: `docker.errors.DockerException: Error while fetching server API version`.
- `ruff` could not run because the executable is not installed in this environment.


