### PR TITLE
Add support for Airflow 3.2 & Airflow 3.3

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,10 +70,10 @@ The React app talks to the *target* Airflow via a `/proxy` endpoint on the *sour
 
 - `tests/` — pytest. `tests/conftest.py` defines a `manual_tests` skip marker gated on `MANUAL_TESTS` env var. `tests/docker_test/` and `tests/resources/` are excluded from collection (`norecursedirs`). `tests/e2e/{gcc,mwaa}/` are integration scaffolds run via their own justfiles.
 - `astronomer_starship/tests/` — vitest tests for the React frontend.
-- Both AF2 and AF3 implementations are exercised — running tests requires `apache-airflow<3.2` from the dev extra. The `--doctest-modules` flag means docstrings with `>>>` examples run as tests.
+- Both AF2 and AF3 implementations are exercised — running tests requires `apache-airflow<3.4` from the dev extra. The `--doctest-modules` flag means docstrings with `>>>` examples run as tests.
 
 ## Constraints worth knowing
 
 - `requires-python = ">=3.6"` (the package still supports the very old Pythons that older Airflow 2 deployments ran on). Ruff is pinned to `target-version = "py37"` accordingly. Don't use 3.8+ syntax (walrus, f-string `=`, etc.) in shipped code.
-- Starship only supports Airflow up to 3.1 right now (`apache-airflow<3.2` in dev extra).
+- Starship supports Airflow up to 3.3 (`apache-airflow<3.4` in dev extra).
 - Releases: a release manager runs `just release MAJOR|MINOR|PATCH` from an up-to-date `main` branch. This uses [commitizen](https://commitizen-tools.github.io/commitizen/) to bump `__version__` in `astronomer_starship/__init__.py`, create a bump commit and a `v<version>` tag, and push both to GitHub. CI then builds and publishes the package directly to PyPI.

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -383,7 +383,7 @@ class StarshipAirflow30(StarshipAirflow):
 
         try:
             engine = self.session.get_bind()
-            metadata = MetaData(bind=engine)
+            metadata = MetaData()
             metadata.reflect(engine, only=["dag_run"])
             table = metadata.tables["dag_run"]
 
@@ -654,7 +654,7 @@ class StarshipAirflow30(StarshipAirflow):
 
         try:
             engine = self.session.get_bind()
-            metadata = MetaData(bind=engine)
+            metadata = MetaData()
 
             metadata.reflect(engine, only=["dag_run"])
             dag_run_table = metadata.tables["dag_run"]
@@ -1002,7 +1002,7 @@ class StarshipAirflow30(StarshipAirflow):
                 item["executor_config"] = pickle.dumps({})
         try:
             engine = self.session.get_bind()
-            metadata = MetaData(bind=engine)
+            metadata = MetaData()
             metadata.reflect(engine, only=[table_name])
             table = metadata.tables[table_name]
 
@@ -1043,7 +1043,7 @@ class StarshipAirflow30(StarshipAirflow):
 
         try:
             engine = self.session.get_bind()
-            metadata = MetaData(bind=engine)
+            metadata = MetaData()
             metadata.reflect(engine, only=["dag_version"])
             dag_version_table = metadata.tables["dag_version"]
 
@@ -1077,7 +1077,7 @@ class StarshipAirflow30(StarshipAirflow):
                     )
 
             engine = self.session.get_bind()
-            metadata = MetaData(bind=engine)
+            metadata = MetaData()
             metadata.reflect(engine, only=["dag_run", "task_instance", "task_instance_history"])
 
             dr_table = metadata.tables["dag_run"]

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -1158,11 +1158,110 @@ class StarshipAirflow31(StarshipAirflow30):
         return attrs
 
 
+class StarshipAirflow32(StarshipAirflow31):
+    """Airflow 3.2 compatibility layer.
+
+    Schema deltas Starship needs to know about:
+    - Pool/Variable/Connection: `team_id` (UUID FK) renamed to `team_name` (String FK to `team.name`, nullable).
+      Exposed read-only: `team_name` is a deployment-local FK, users must pre-create matching teams on target.
+    - DagRun: `partition_key`, `partition_date`, `created_at` added (all nullable).
+    """
+
+    @classmethod
+    def pool_attrs(cls) -> "Dict[str, AttrDesc]":
+        attrs = super().pool_attrs()
+        attrs["team_name"] = {"attr": "team_name", "methods": [], "test_value": None}
+        return attrs
+
+    @classmethod
+    def variable_attrs(cls) -> "Dict[str, AttrDesc]":
+        attrs = super().variable_attrs()
+        attrs["team_name"] = {"attr": "team_name", "methods": [], "test_value": None}
+        return attrs
+
+    @classmethod
+    def connection_attrs(cls) -> "Dict[str, AttrDesc]":
+        attrs = super().connection_attrs()
+        attrs["team_name"] = {"attr": "team_name", "methods": [], "test_value": None}
+        return attrs
+
+    @classmethod
+    def dag_run_attrs(cls) -> "Dict[str, AttrDesc]":
+        attrs = super().dag_run_attrs()
+        epoch = datetime.datetime(1970, 1, 1, 0, 0).replace(tzinfo=timezone.utc)
+        attrs["created_at"] = {
+            "attr": "created_at",
+            "methods": [("POST", False)],
+            "test_value": epoch,
+        }
+        attrs["partition_key"] = {
+            "attr": "partition_key",
+            "methods": [("POST", False)],
+            "test_value": "partition_key",
+        }
+        attrs["partition_date"] = {
+            "attr": "partition_date",
+            "methods": [("POST", False)],
+            "test_value": epoch,
+        }
+        return attrs
+
+    @classmethod
+    def dag_runs_attrs(cls) -> "Dict[str, AttrDesc]":
+        attrs = super().dag_runs_attrs()
+        epoch = datetime.datetime(1970, 1, 1, 0, 0).replace(tzinfo=timezone.utc)
+        attrs["dag_runs"]["test_value"][0].update(
+            {
+                "created_at": epoch,
+                "partition_key": "partition_key",
+                "partition_date": epoch,
+            }
+        )
+        return attrs
+
+
+class StarshipAirflow33(StarshipAirflow32):
+    """Airflow 3.3 compatibility layer.
+
+    Schema deltas Starship needs to know about:
+    - TaskInstance: `retry_delay_override` and `retry_reason` added (both nullable, AIP-105 pluggable retry policies).
+    - dag_version: `version_data` added (nullable). Transparent to Starship, only `id`/`version_number` are read.
+    """
+
+    @classmethod
+    def task_instance_attrs(cls) -> "Dict[str, AttrDesc]":
+        attrs = super().task_instance_attrs()
+        attrs["retry_delay_override"] = {
+            "attr": "retry_delay_override",
+            "methods": [("POST", False)],
+            "test_value": None,
+        }
+        attrs["retry_reason"] = {
+            "attr": "retry_reason",
+            "methods": [("POST", False)],
+            "test_value": None,
+        }
+        return attrs
+
+    @classmethod
+    def task_instances_attrs(cls) -> "Dict[str, AttrDesc]":
+        attrs = super().task_instances_attrs()
+        attrs["task_instances"]["test_value"][0].update(
+            {
+                "retry_delay_override": None,
+                "retry_reason": None,
+            }
+        )
+        return attrs
+
+
 class StarshipCompatabilityLayer:
     """StarshipCompatabilityLayer is a factory class that returns the correct StarshipAirflow class for a version
 
     - 3.0 https://github.com/apache/airflow/tree/3.0.0/airflow-core/src/airflow/models
     - 3.1 https://github.com/apache/airflow/tree/3.1.0/airflow-core/src/airflow/models
+    - 3.2 https://github.com/apache/airflow/tree/3.2.0/airflow-core/src/airflow/models
+    - 3.3 https://github.com/apache/airflow/tree/3.3.0/airflow-core/src/airflow/models
     """
 
     def __new__(cls, airflow_version: "Union[str, None]" = None) -> StarshipAirflow:
@@ -1180,5 +1279,9 @@ class StarshipCompatabilityLayer:
                 return StarshipAirflow30()
             elif minor == 1:
                 return StarshipAirflow31()
+            elif minor == 2:
+                return StarshipAirflow32()
+            elif minor == 3:
+                return StarshipAirflow33()
 
         raise RuntimeError(f"Unsupported Airflow Version: {airflow_version}")

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -1122,66 +1122,58 @@ class StarshipAirflow30(StarshipAirflow):
 
 
 class StarshipAirflow31(StarshipAirflow30):
-    """Airflow 3.1 compatibility layer."""
+    """Airflow 3.1 compatibility layer.
+
+    Schema deltas:
+    - Pool/Variable/Connection: `team_id` (UUID FK to `team.id`, nullable) added.
+    """
 
     @classmethod
     def pool_attrs(cls) -> "Dict[str, AttrDesc]":
         attrs = super().pool_attrs()
-        # TODO: add support for Teams? (added in 3.1)
-        # attrs["team_id"] = {
-        #     "attr": "team_id",
-        #     "methods": [("POST", True)],
-        #     "test_value": 123,
-        # }
+        attrs["team_id"] = {"attr": "team_id", "methods": [], "test_value": None}
         return attrs
 
     @classmethod
     def variable_attrs(cls) -> "Dict[str, AttrDesc]":
         attrs = super().variable_attrs()
-        # TODO: add support for Teams? (added in 3.1)
-        # attrs["team_id"] = {
-        #     "attr": "team_id",
-        #     "methods": [("POST", True)],
-        #     "test_value": 123,
-        # }
+        attrs["team_id"] = {"attr": "team_id", "methods": [], "test_value": None}
         return attrs
 
     @classmethod
     def connection_attrs(cls) -> "Dict[str, AttrDesc]":
         attrs = super().connection_attrs()
-        # TODO: add support for Teams? (added in 3.1)
-        # attrs["team_id"] = {
-        #     "attr": "team_id",
-        #     "methods": [("POST", True)],
-        #     "test_value": 123,
-        # }
+        attrs["team_id"] = {"attr": "team_id", "methods": [], "test_value": None}
         return attrs
 
 
 class StarshipAirflow32(StarshipAirflow31):
     """Airflow 3.2 compatibility layer.
 
-    Schema deltas Starship needs to know about:
-    - Pool/Variable/Connection: `team_id` (UUID FK) renamed to `team_name` (String FK to `team.name`, nullable).
-      Exposed read-only: `team_name` is a deployment-local FK, users must pre-create matching teams on target.
+    Schema deltas:
+    - Pool/Variable/Connection: `team_id` renamed to `team_name` (String FK,
+      nullable). Read-only.
     - DagRun: `partition_key`, `partition_date`, `created_at` added (all nullable).
     """
 
     @classmethod
     def pool_attrs(cls) -> "Dict[str, AttrDesc]":
         attrs = super().pool_attrs()
+        attrs.pop("team_id", None)
         attrs["team_name"] = {"attr": "team_name", "methods": [], "test_value": None}
         return attrs
 
     @classmethod
     def variable_attrs(cls) -> "Dict[str, AttrDesc]":
         attrs = super().variable_attrs()
+        attrs.pop("team_id", None)
         attrs["team_name"] = {"attr": "team_name", "methods": [], "test_value": None}
         return attrs
 
     @classmethod
     def connection_attrs(cls) -> "Dict[str, AttrDesc]":
         attrs = super().connection_attrs()
+        attrs.pop("team_id", None)
         attrs["team_name"] = {"attr": "team_name", "methods": [], "test_value": None}
         return attrs
 
@@ -1223,9 +1215,10 @@ class StarshipAirflow32(StarshipAirflow31):
 class StarshipAirflow33(StarshipAirflow32):
     """Airflow 3.3 compatibility layer.
 
-    Schema deltas Starship needs to know about:
-    - TaskInstance: `retry_delay_override` and `retry_reason` added (both nullable, AIP-105 pluggable retry policies).
-    - dag_version: `version_data` added (nullable). Transparent to Starship, only `id`/`version_number` are read.
+    Schema deltas:
+    - TaskInstance: `retry_delay_override` (Float) and `retry_reason` (String) added
+      (both nullable, AIP-105 pluggable retry policies).
+    - dag_version: `version_data` added (nullable). Transparent to Starship.
     """
 
     @classmethod
@@ -1258,10 +1251,10 @@ class StarshipAirflow33(StarshipAirflow32):
 class StarshipCompatabilityLayer:
     """StarshipCompatabilityLayer is a factory class that returns the correct StarshipAirflow class for a version
 
-    - 3.0 https://github.com/apache/airflow/tree/3.0.0/airflow-core/src/airflow/models
-    - 3.1 https://github.com/apache/airflow/tree/3.1.0/airflow-core/src/airflow/models
-    - 3.2 https://github.com/apache/airflow/tree/3.2.0/airflow-core/src/airflow/models
-    - 3.3 https://github.com/apache/airflow/tree/3.3.0/airflow-core/src/airflow/models
+    - 3.0 https://github.com/apache/airflow/tree/3.0.6/airflow-core/src/airflow/models
+    - 3.1 https://github.com/apache/airflow/tree/3.1.8/airflow-core/src/airflow/models
+    - 3.2 https://github.com/apache/airflow/tree/3.2.2/airflow-core/src/airflow/models
+    - 3.3 https://github.com/apache/airflow/tree/3.3.1/airflow-core/src/airflow/models
     """
 
     def __new__(cls, airflow_version: "Union[str, None]" = None) -> StarshipAirflow:

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -325,6 +325,8 @@ _DATETIME_KEYS = {
     "execution_date",
     "queued_dttm",
     "scheduled_dttm",
+    "created_at",
+    "partition_date",
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]
@@ -71,7 +73,7 @@ dev = [
     "commitizen",
 
     # test
-    "apache-airflow<3.2", # Starship only supports Airflow version up to 3.1 at the moment
+    "apache-airflow<3.4", # Starship supports Airflow versions up to 3.3
     "pytest>=7",
     "pytest-cov>=4.0",
     "pytest-integration>=0.2",

--- a/tests/af3_compatability_dispatch_test.py
+++ b/tests/af3_compatability_dispatch_test.py
@@ -63,7 +63,7 @@ def test_compatability_layer_dispatches_to_correct_subclass(airflow_version, exp
     assert isinstance(instance, expected_cls)
 
 
-@pytest.mark.parametrize("airflow_version", ["2.11.0", "3.4.0", "4.0.0"])
+@pytest.mark.parametrize("airflow_version", ["3.4.0", "4.0.0"])
 def test_compatability_layer_raises_for_unsupported_versions(airflow_version):
     with pytest.raises(RuntimeError, match="Unsupported Airflow Version"):
         StarshipCompatabilityLayer(airflow_version=airflow_version)

--- a/tests/af3_compatability_dispatch_test.py
+++ b/tests/af3_compatability_dispatch_test.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from astronomer_starship._af3.starship_compatability import (
@@ -7,6 +9,40 @@ from astronomer_starship._af3.starship_compatability import (
     StarshipAirflow33,
     StarshipCompatabilityLayer,
 )
+
+ALL_AF3_SUBCLASSES = [
+    StarshipAirflow30,
+    StarshipAirflow31,
+    StarshipAirflow32,
+    StarshipAirflow33,
+]
+
+ATTR_METHODS = [
+    "pool_attrs",
+    "variable_attrs",
+    "connection_attrs",
+    "dag_run_attrs",
+    "task_instance_attrs",
+    "dag_runs_attrs",
+    "task_instances_attrs",
+]
+
+# (list-endpoint method, key holding the row payload, item-endpoint method).
+LIST_TO_ITEM = [
+    ("dag_runs_attrs", "dag_runs", "dag_run_attrs"),
+    ("task_instances_attrs", "task_instances", "task_instance_attrs"),
+]
+
+
+def _walk_datetimes(value):
+    if isinstance(value, datetime.datetime):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _walk_datetimes(v)
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            yield from _walk_datetimes(v)
 
 
 @pytest.mark.parametrize(
@@ -88,3 +124,67 @@ def test_starship_airflow31_does_not_have_32_or_33_additions():
     assert "team_name" not in StarshipAirflow31.pool_attrs()
     assert "created_at" not in StarshipAirflow31.dag_run_attrs()
     assert "retry_delay_override" not in StarshipAirflow31.task_instance_attrs()
+
+
+@pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
+@pytest.mark.parametrize("method_name", ATTR_METHODS)
+def test_attrs_method_returns_wellformed_desc(cls, method_name):
+    attrs = getattr(cls, method_name)()
+    assert isinstance(attrs, dict) and attrs, f"{cls.__name__}.{method_name} returned empty"
+
+    for key, desc in attrs.items():
+        assert {
+            "attr",
+            "methods",
+            "test_value",
+        } <= desc.keys(), f"{cls.__name__}.{method_name}[{key!r}] missing keys: got {set(desc)}"
+        assert isinstance(desc["methods"], list)
+        for entry in desc["methods"]:
+            assert isinstance(entry, tuple) and len(entry) == 2, entry
+            verb, required = entry
+            assert verb in {"GET", "POST", "PUT", "DELETE", "PATCH"}, verb
+            assert isinstance(required, bool)
+
+
+@pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
+@pytest.mark.parametrize("list_method,list_key,item_method", LIST_TO_ITEM)
+def test_list_payload_row_matches_item_attrs(cls, list_method, list_key, item_method):
+    # The row shipped in the list endpoint's test_value must have the same keys
+    # as the item endpoint's attrs -- otherwise docker validation silently drifts.
+    row = getattr(cls, list_method)()[list_key]["test_value"][0]
+    item_keys = set(getattr(cls, item_method)().keys())
+    assert set(row.keys()) == item_keys, (
+        f"{cls.__name__}: {list_method}[{list_key!r}] row keys diverge from {item_method}: "
+        f"symmetric diff = {set(row.keys()) ^ item_keys}"
+    )
+
+
+@pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
+@pytest.mark.parametrize("method_name", ATTR_METHODS)
+def test_subclass_never_shrinks_parent_attrs(cls, method_name):
+    parent = cls.__mro__[1]
+    if parent not in ALL_AF3_SUBCLASSES:
+        pytest.skip(f"{parent.__name__} is the abstract base; no parent attrs to compare")
+    dropped = set(getattr(parent, method_name)()) - set(getattr(cls, method_name)())
+    assert not dropped, f"{cls.__name__}.{method_name} dropped inherited columns: {dropped}"
+
+
+@pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
+@pytest.mark.parametrize("method_name", ATTR_METHODS)
+def test_datetime_test_values_are_timezone_aware(cls, method_name):
+    # Naive datetimes round-trip as naive through Airflow's UtcDateTime and mismatch
+    # tz-aware API responses -- the exact class of bug we hit on created_at / partition_date.
+    attrs = getattr(cls, method_name)()
+    naive = [dt for desc in attrs.values() for dt in _walk_datetimes(desc["test_value"]) if dt.tzinfo is None]
+    assert not naive, f"{cls.__name__}.{method_name} has naive datetimes: {naive}"
+
+
+def test_compatability_layer_defaults_to_installed_airflow_version(monkeypatch):
+    # Covers the `airflow_version is None` branch in __new__ that reads airflow.__version__.
+    import airflow
+
+    monkeypatch.setattr(airflow, "__version__", "3.2.2", raising=False)
+    assert isinstance(StarshipCompatabilityLayer(), StarshipAirflow32)
+
+    monkeypatch.setattr(airflow, "__version__", "3.3.1", raising=False)
+    assert isinstance(StarshipCompatabilityLayer(), StarshipAirflow33)

--- a/tests/af3_compatability_dispatch_test.py
+++ b/tests/af3_compatability_dispatch_test.py
@@ -1,0 +1,57 @@
+import pytest
+
+from astronomer_starship._af3.starship_compatability import (
+    StarshipAirflow30,
+    StarshipAirflow31,
+    StarshipAirflow32,
+    StarshipAirflow33,
+    StarshipCompatabilityLayer,
+)
+
+
+@pytest.mark.parametrize(
+    "airflow_version,expected_cls",
+    [
+        ("3.0.0", StarshipAirflow30),
+        ("3.0.6", StarshipAirflow30),
+        ("3.1.0", StarshipAirflow31),
+        ("3.1.8", StarshipAirflow31),
+        ("3.2.0", StarshipAirflow32),
+        ("3.2.2", StarshipAirflow32),
+        ("3.3.0", StarshipAirflow33),
+        ("3.3.1", StarshipAirflow33),
+    ],
+)
+def test_compatability_layer_dispatches_to_correct_subclass(airflow_version, expected_cls):
+    instance = StarshipCompatabilityLayer(airflow_version=airflow_version)
+    assert isinstance(instance, expected_cls)
+
+
+@pytest.mark.parametrize("airflow_version", ["2.11.0", "3.4.0", "4.0.0"])
+def test_compatability_layer_raises_for_unsupported_versions(airflow_version):
+    with pytest.raises(RuntimeError, match="Unsupported Airflow Version"):
+        StarshipCompatabilityLayer(airflow_version=airflow_version)
+
+
+def test_starship_airflow32_exposes_team_name_read_only():
+    for attrs_fn in (
+        StarshipAirflow32.pool_attrs,
+        StarshipAirflow32.variable_attrs,
+        StarshipAirflow32.connection_attrs,
+    ):
+        team_name = attrs_fn()["team_name"]
+        # `team_name` is a deployment-local FK to `team.name`; migrating it blindly
+        # can fail with FK violations if the target hasn't created the same teams.
+        assert team_name["methods"] == []
+
+
+def test_starship_airflow32_exposes_new_dag_run_columns():
+    dag_run_attrs = StarshipAirflow32.dag_run_attrs()
+    for col in ("created_at", "partition_key", "partition_date"):
+        assert col in dag_run_attrs, f"{col} missing from StarshipAirflow32.dag_run_attrs"
+
+
+def test_starship_airflow33_exposes_new_task_instance_columns():
+    task_instance_attrs = StarshipAirflow33.task_instance_attrs()
+    for col in ("retry_delay_override", "retry_reason"):
+        assert col in task_instance_attrs, f"{col} missing from StarshipAirflow33.task_instance_attrs"

--- a/tests/af3_compatability_dispatch_test.py
+++ b/tests/af3_compatability_dispatch_test.py
@@ -55,3 +55,36 @@ def test_starship_airflow33_exposes_new_task_instance_columns():
     task_instance_attrs = StarshipAirflow33.task_instance_attrs()
     for col in ("retry_delay_override", "retry_reason"):
         assert col in task_instance_attrs, f"{col} missing from StarshipAirflow33.task_instance_attrs"
+
+
+def test_starship_airflow33_inherits_all_32_additions():
+    # A future 3.3-only override that forgets `super()` would silently drop 3.2's schema deltas.
+    for attrs_fn in (
+        StarshipAirflow33.pool_attrs,
+        StarshipAirflow33.variable_attrs,
+        StarshipAirflow33.connection_attrs,
+    ):
+        assert "team_name" in attrs_fn()
+
+    dag_run_attrs = StarshipAirflow33.dag_run_attrs()
+    for col in ("created_at", "partition_key", "partition_date"):
+        assert col in dag_run_attrs
+
+
+def test_dag_runs_test_value_payload_carries_new_columns():
+    # The list-endpoint payloads drive docker validation -- assert the row shape stays in sync
+    # with dag_run_attrs so a stale payload can't silently pass validation.
+    row_32 = StarshipAirflow32.dag_runs_attrs()["dag_runs"]["test_value"][0]
+    for col in ("created_at", "partition_key", "partition_date"):
+        assert col in row_32, f"{col} missing from StarshipAirflow32.dag_runs_attrs payload"
+
+    row_33 = StarshipAirflow33.task_instances_attrs()["task_instances"]["test_value"][0]
+    for col in ("retry_delay_override", "retry_reason"):
+        assert col in row_33, f"{col} missing from StarshipAirflow33.task_instances_attrs payload"
+
+
+def test_starship_airflow31_does_not_have_32_or_33_additions():
+    # Guards against a future refactor moving a 3.2/3.3 delta into the base class by accident.
+    assert "team_name" not in StarshipAirflow31.pool_attrs()
+    assert "created_at" not in StarshipAirflow31.dag_run_attrs()
+    assert "retry_delay_override" not in StarshipAirflow31.task_instance_attrs()

--- a/tests/af3_compatability_dispatch_test.py
+++ b/tests/af3_compatability_dispatch_test.py
@@ -69,16 +69,37 @@ def test_compatability_layer_raises_for_unsupported_versions(airflow_version):
         StarshipCompatabilityLayer(airflow_version=airflow_version)
 
 
+def test_starship_airflow31_exposes_team_id_read_only():
+    for attrs_fn in (
+        StarshipAirflow31.pool_attrs,
+        StarshipAirflow31.variable_attrs,
+        StarshipAirflow31.connection_attrs,
+    ):
+        # team UUIDs are deployment-local, so team_id can't be POSTed cross-deployment.
+        assert attrs_fn()["team_id"]["methods"] == []
+
+
 def test_starship_airflow32_exposes_team_name_read_only():
     for attrs_fn in (
         StarshipAirflow32.pool_attrs,
         StarshipAirflow32.variable_attrs,
         StarshipAirflow32.connection_attrs,
     ):
-        team_name = attrs_fn()["team_name"]
-        # `team_name` is a deployment-local FK to `team.name`; migrating it blindly
-        # can fail with FK violations if the target hasn't created the same teams.
-        assert team_name["methods"] == []
+        # team names must be pre-created on target; leaving this writable would FK-violate.
+        assert attrs_fn()["team_name"]["methods"] == []
+
+
+def test_starship_airflow32_drops_team_id_after_rename():
+    # 3.2 renames team_id -> team_name; leaving team_id in attrs would surface
+    # a phantom column on GET (no such column in the 3.2 DB).
+    for attrs_fn in (
+        StarshipAirflow32.pool_attrs,
+        StarshipAirflow32.variable_attrs,
+        StarshipAirflow32.connection_attrs,
+    ):
+        attrs = attrs_fn()
+        assert "team_id" not in attrs
+        assert "team_name" in attrs
 
 
 def test_starship_airflow32_exposes_new_dag_run_columns():
@@ -94,7 +115,6 @@ def test_starship_airflow33_exposes_new_task_instance_columns():
 
 
 def test_starship_airflow33_inherits_all_32_additions():
-    # A future 3.3-only override that forgets `super()` would silently drop 3.2's schema deltas.
     for attrs_fn in (
         StarshipAirflow33.pool_attrs,
         StarshipAirflow33.variable_attrs,
@@ -108,8 +128,6 @@ def test_starship_airflow33_inherits_all_32_additions():
 
 
 def test_dag_runs_test_value_payload_carries_new_columns():
-    # The list-endpoint payloads drive docker validation -- assert the row shape stays in sync
-    # with dag_run_attrs so a stale payload can't silently pass validation.
     row_32 = StarshipAirflow32.dag_runs_attrs()["dag_runs"]["test_value"][0]
     for col in ("created_at", "partition_key", "partition_date"):
         assert col in row_32, f"{col} missing from StarshipAirflow32.dag_runs_attrs payload"
@@ -120,7 +138,6 @@ def test_dag_runs_test_value_payload_carries_new_columns():
 
 
 def test_starship_airflow31_does_not_have_32_or_33_additions():
-    # Guards against a future refactor moving a 3.2/3.3 delta into the base class by accident.
     assert "team_name" not in StarshipAirflow31.pool_attrs()
     assert "created_at" not in StarshipAirflow31.dag_run_attrs()
     assert "retry_delay_override" not in StarshipAirflow31.task_instance_attrs()
@@ -149,8 +166,6 @@ def test_attrs_method_returns_wellformed_desc(cls, method_name):
 @pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
 @pytest.mark.parametrize("list_method,list_key,item_method", LIST_TO_ITEM)
 def test_list_payload_row_matches_item_attrs(cls, list_method, list_key, item_method):
-    # The row shipped in the list endpoint's test_value must have the same keys
-    # as the item endpoint's attrs -- otherwise docker validation silently drifts.
     row = getattr(cls, list_method)()[list_key]["test_value"][0]
     item_keys = set(getattr(cls, item_method)().keys())
     assert set(row.keys()) == item_keys, (
@@ -159,28 +174,38 @@ def test_list_payload_row_matches_item_attrs(cls, list_method, list_key, item_me
     )
 
 
+# Columns a subclass is allowed to drop relative to its parent (documented DB renames).
+KNOWN_DROPPED_COLUMNS = {
+    # 3.2 renames team_id -> team_name
+    (StarshipAirflow32, "pool_attrs"): {"team_id"},
+    (StarshipAirflow32, "variable_attrs"): {"team_id"},
+    (StarshipAirflow32, "connection_attrs"): {"team_id"},
+}
+
+
 @pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
 @pytest.mark.parametrize("method_name", ATTR_METHODS)
 def test_subclass_never_shrinks_parent_attrs(cls, method_name):
     parent = cls.__mro__[1]
     if parent not in ALL_AF3_SUBCLASSES:
         pytest.skip(f"{parent.__name__} is the abstract base; no parent attrs to compare")
-    dropped = set(getattr(parent, method_name)()) - set(getattr(cls, method_name)())
+    allowed = KNOWN_DROPPED_COLUMNS.get((cls, method_name), set())
+    dropped = (set(getattr(parent, method_name)()) - set(getattr(cls, method_name)())) - allowed
     assert not dropped, f"{cls.__name__}.{method_name} dropped inherited columns: {dropped}"
 
 
 @pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
 @pytest.mark.parametrize("method_name", ATTR_METHODS)
 def test_datetime_test_values_are_timezone_aware(cls, method_name):
-    # Naive datetimes round-trip as naive through Airflow's UtcDateTime and mismatch
-    # tz-aware API responses -- the exact class of bug we hit on created_at / partition_date.
+    # Naive datetimes round-trip through Airflow's UtcDateTime naive, but API
+    # responses come back tz-aware -- equality then breaks.
     attrs = getattr(cls, method_name)()
     naive = [dt for desc in attrs.values() for dt in _walk_datetimes(desc["test_value"]) if dt.tzinfo is None]
     assert not naive, f"{cls.__name__}.{method_name} has naive datetimes: {naive}"
 
 
 def test_compatability_layer_defaults_to_installed_airflow_version(monkeypatch):
-    # Covers the `airflow_version is None` branch in __new__ that reads airflow.__version__.
+    # Exercises the `airflow_version is None` branch in __new__.
     import airflow
 
     monkeypatch.setattr(airflow, "__version__", "3.2.2", raising=False)

--- a/tests/af3_insert_sanitization_test.py
+++ b/tests/af3_insert_sanitization_test.py
@@ -32,7 +32,7 @@ class FakeTable:
 
 
 class FakeMetaData:
-    def __init__(self, bind):
+    def __init__(self, bind=None):
         self.tables = {}
 
     def reflect(self, engine, only):

--- a/tests/af3_insert_sanitization_test.py
+++ b/tests/af3_insert_sanitization_test.py
@@ -1,4 +1,15 @@
-from astronomer_starship._af3.starship_compatability import StarshipAirflow31
+import pytest
+
+from astronomer_starship._af3.starship_compatability import (
+    StarshipAirflow31,
+    StarshipAirflow32,
+    StarshipAirflow33,
+)
+
+# insert_directly is defined on StarshipAirflow30 and inherited unchanged --
+# parametrize FK-stripping tests over every subclass to guard against a future override
+# silently dropping the stripping logic.
+STARSHIP_SUBCLASSES = [StarshipAirflow31, StarshipAirflow32, StarshipAirflow33]
 
 
 class FakeColumn:
@@ -61,12 +72,13 @@ class FakeSession:
         raise AssertionError("rollback should not be called")
 
 
-def test_dag_run_direct_insert_strips_source_log_template_id(monkeypatch):
+@pytest.mark.parametrize("starship_cls", STARSHIP_SUBCLASSES)
+def test_dag_run_direct_insert_strips_source_log_template_id(monkeypatch, starship_cls):
     import sqlalchemy
     import sqlalchemy.dialects.postgresql
 
     fake_session = FakeSession()
-    starship = StarshipAirflow31()
+    starship = starship_cls()
     starship._session = fake_session
 
     monkeypatch.setattr(sqlalchemy, "MetaData", FakeMetaData)
@@ -93,12 +105,13 @@ def test_dag_run_direct_insert_strips_source_log_template_id(monkeypatch):
     assert result == [{"dag_id": "example_dag", "run_id": "scheduled__2026-08-01T00:00:00+00:00"}]
 
 
-def test_dag_run_direct_insert_strips_source_backfill_id(monkeypatch):
+@pytest.mark.parametrize("starship_cls", STARSHIP_SUBCLASSES)
+def test_dag_run_direct_insert_strips_source_backfill_id(monkeypatch, starship_cls):
     import sqlalchemy
     import sqlalchemy.dialects.postgresql
 
     fake_session = FakeSession()
-    starship = StarshipAirflow31()
+    starship = starship_cls()
     starship._session = fake_session
 
     monkeypatch.setattr(sqlalchemy, "MetaData", FakeMetaData)
@@ -125,12 +138,13 @@ def test_dag_run_direct_insert_strips_source_backfill_id(monkeypatch):
     assert result == [{"dag_id": "example_dag", "run_id": "backfill__2026-08-01T00:00:00+00:00"}]
 
 
-def test_task_instance_direct_insert_strips_source_trigger_id(monkeypatch):
+@pytest.mark.parametrize("starship_cls", STARSHIP_SUBCLASSES)
+def test_task_instance_direct_insert_strips_source_trigger_id(monkeypatch, starship_cls):
     import sqlalchemy
     import sqlalchemy.dialects.postgresql
 
     fake_session = FakeSession()
-    starship = StarshipAirflow31()
+    starship = starship_cls()
     starship._session = fake_session
 
     monkeypatch.setattr(sqlalchemy, "MetaData", FakeMetaData)

--- a/tests/docker_test/docker_test.py
+++ b/tests/docker_test/docker_test.py
@@ -44,10 +44,11 @@ def test_info(starship):
 def test_variables(starship):
     test_input = get_test_data(method="POST", attrs=starship.variable_attrs())
     actual = starship.set_variable(**test_input)
-    assert actual == test_input, actual
+    # Filter to POST-able keys so read-only compat-layer fields (e.g. `team_name` on AF3.2+) don't break equality.
+    assert {k: v for k, v in actual.items() if k in test_input} == test_input, actual
 
     actual = starship.get_variables()
-    assert test_input in actual, actual
+    assert any(test_input.items() <= a.items() for a in actual), actual
 
     test_input = get_test_data(method="DELETE", attrs=starship.variable_attrs())
     actual = starship.delete_variable(**test_input)
@@ -66,10 +67,11 @@ def test_pools(starship):
     del test_input["name"]
 
     actual = starship.set_pool(**test_input)
-    assert actual == expected, actual
+    # Filter to POST-able keys so read-only compat-layer fields (e.g. `team_name` on AF3.2+) don't break equality.
+    assert {k: v for k, v in actual.items() if k in expected} == expected, actual
 
     actual = starship.get_pools()
-    assert expected in actual, actual
+    assert any(expected.items() <= a.items() for a in actual), actual
 
     test_input = get_test_data(method="DELETE", attrs=starship.pool_attrs())
     actual = starship.delete_pool(**test_input)
@@ -80,10 +82,11 @@ def test_pools(starship):
 def test_connections(starship):
     test_input = get_test_data(method="POST", attrs=starship.connection_attrs())
     actual = starship.set_connection(**test_input)
-    assert actual == test_input, actual
+    # Filter to POST-able keys so read-only compat-layer fields (e.g. `team_name` on AF3.2+) don't break equality.
+    assert {k: v for k, v in actual.items() if k in test_input} == test_input, actual
 
     actual = starship.get_connections()
-    assert test_input in actual, actual
+    assert any(test_input.items() <= a.items() for a in actual), actual
 
     test_input = get_test_data(method="DELETE", attrs=starship.connection_attrs())
     actual = starship.delete_connection(**test_input)

--- a/tests/validation_test.py
+++ b/tests/validation_test.py
@@ -26,6 +26,8 @@ ASTRO_IMAGES = [
 ]
 
 IMAGES = [
+    "apache/airflow:slim-3.3.0",
+    "apache/airflow:slim-3.2.0",
     "apache/airflow:slim-3.1.1",
     "apache/airflow:slim-3.0.6",
     "apache/airflow:slim-2.11.0",

--- a/tests/validation_test.py
+++ b/tests/validation_test.py
@@ -26,8 +26,8 @@ ASTRO_IMAGES = [
 ]
 
 IMAGES = [
-    "apache/airflow:slim-3.3.0",
-    "apache/airflow:slim-3.2.0",
+    "apache/airflow:slim-3.3.1",
+    "apache/airflow:slim-3.2.2",
     "apache/airflow:slim-3.1.1",
     "apache/airflow:slim-3.0.6",
     "apache/airflow:slim-2.11.0",

--- a/tests/validation_test.py
+++ b/tests/validation_test.py
@@ -28,7 +28,7 @@ ASTRO_IMAGES = [
 IMAGES = [
     "apache/airflow:slim-3.3.1",
     "apache/airflow:slim-3.2.2",
-    "apache/airflow:slim-3.1.1",
+    "apache/airflow:slim-3.1.8",
     "apache/airflow:slim-3.0.6",
     "apache/airflow:slim-2.11.0",
     "apache/airflow:slim-2.10.3",


### PR DESCRIPTION
### 🤖 This PR was drafted with assistance from Claude Opus 4.7

### Closes
- #176 
- #175 

## What was changed?
Adds a compatibility layer for Airflow 3.2 and 3.3, plus Python 3.13/3.14 to the CI matrix and package classifiers.

### Compatibility layer
- `StarshipAirflow32(StarshipAirflow31)` - Adds `team_name` (read-only) on Pool/Variable/Connection and `created_at`, `partition_key`, `partition_date` on DagRun.
- `StarshipAirflow33(StarshipAirflow32)` - Adds `retry_delay_override` and `retry_reason` on TaskInstance (AIP-105 pluggable retry policies).
- `StarshipCompatabilityLayer` routes `minor == 2` and `minor == 3` to the new subclasses.

### Package + CI
- Added Python 3.13 and 3.14 to Trove classifiers and the test matrix.
- Added `slim-3.2.2`, `slim-3.3.1`, and `slim-3.1.8`  to the docker validation image list.

### Fix
Removed the deprecated `MetaData(bind=engine)` kwarg from five call sites in `_af3/starship_compatability.py`. SQLAlchemy 2.x (shipped by Airflow 3.2) removed the argument. The subsequent `metadata.reflect(engine, only=[...])` already binds correctly, so the change is a no-op on SQLA 1.4 and fixes SQLA 2.x.

### Unit Tests
- Parametrized existing FK-strip regression tests over `StarshipAirflow31/32/33`.
- New `tests/af3_compatability_dispatch_test.py` covering:
  - version dispatch (3.0/3.1/3.2/3.3 with patch variants)
  - `RuntimeError` on unsupported versions
  - `team_name` read-only on Pool/Variable/Connection
  - new DagRun and TaskInstance columns per subclass
  - `StarshipAirflow33` inherits all 3.2 additions
  - list-endpoint `test_value` payload rows stay in sync
  - `StarshipAirflow31` doesn't accidentally carry 3.2/3.3 columns

### Manual Testing [TODO]
- [x] Local `astro dev` testing against Runtime 3.2-8, 3.3-5, 3.1-20 verified plugin registration, version dispatch, and all new attrs entries in real API responses.
- [x] Runtime 3.1-20/Airflow 3.1.8 - source to target migration of Variables, Connections, Pools, DAG History.
- [x] Runtime 3.2-8/Airflow 3.2.2 - source to target migration of Variables, Connections, Pools, DAG History; no FK violations from `team_name`
- [x] Runtime 3.3-5/Airflow 3.3.1 - same migration flow; `retry_delay_override`/`retry_reason` round-trip cleanly
- [x] Verify the Starship UI loads and the proxy handles CORS correctly on both Runtime versions