### PR TITLE
Update Docs - List 3.2/3.3 features in supported table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,8 @@ on the corresponding minimum Airflow version.
 | Task instance notes | 3.0 | ❌ |
 | HITL | 3.1 | ❌ |
 | Teams | 3.1 | ❌ |
+| Partitioned dag runs | 3.2 | ✅ |
+| Pluggable retry policies | 3.3 | ✅ |
 
 ## Security Notice
 


### PR DESCRIPTION
Follow-up to #184 (Airflow 3.2/3.3 support).

Adds two rows to the "Supported Airflow Features" table in `docs/index.md`:

| Feature | Minimum Airflow Version | Supported |
| --- | --- | --- |
| Partitioned dag runs | 3.2 | ✅ |
| Pluggable retry policies | 3.3 | ✅ |

#### Rationale:
- **Partitioned dag runs (3.2)**: `partition_key`, `partition_date`, `created_at` migrate cleanly (POST-enabled in `StarshipAirflow32.dag_run_attrs`).
- **Pluggable retry policies (3.3)**: `retry_delay_override`, `retry_reason` migrate cleanly (POST-enabled in `StarshipAirflow33.task_instance_attrs`).