### PR TITLE
Support Pagination, Search, & Bulk Pause/Unpause on filtered DAGs in DAG History Tab

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,8 @@ repos:
     hooks:
       - id: prettier
         name: prettier
-        entry: npx prettier --write --ignore-unknown
+        entry: npx --yes prettier@3.4.2 --write --ignore-unknown
         language: system
         types_or: [javascript, jsx, css, json]
         files: ^astronomer_starship/(src|tests)/
+        require_serial: true

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -22,6 +22,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _nonneg_int(value, default):
+    """Return `value` coerced to a non-negative int, or `default` on bad input."""
+    if value in (None, ""):
+        return default
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(n, 0)
+
+
 class StarshipAirflow(BaseStarshipAirflow):
     """Base class for Airflow 2.x compatibility layers.
 
@@ -183,9 +194,11 @@ class StarshipAirflow(BaseStarshipAirflow):
         from sqlalchemy.sql.functions import count
 
         # Query params come in as strings via request.args; coerce.
-        # Treat empty strings as unset (e.g. `?limit=&offset=`).
-        limit = int(limit) if limit not in (None, "") else None
-        offset = int(offset) if offset not in (None, "", 0, "0") else 0
+        # Treat empty strings as unset (e.g. `?limit=&offset=`) and silently
+        # clamp non-int / negative values to safe defaults so bad input yields
+        # a well-formed empty response instead of a 500.
+        limit = _nonneg_int(limit, default=None)
+        offset = _nonneg_int(offset, default=0)
         search = search or None
         search_field = search_field or None
 

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -178,8 +178,10 @@ class StarshipAirflow(BaseStarshipAirflow):
         from sqlalchemy.sql.functions import count
 
         # Query params come in as strings via request.args; coerce.
-        limit = int(limit) if limit is not None else None
-        offset = int(offset) if offset else 0
+        # Treat empty strings as unset (e.g. `?limit=&offset=`).
+        limit = int(limit) if limit not in (None, "") else None
+        offset = int(offset) if offset not in (None, "", 0, "0") else 0
+        search = search or None
 
         # `dag_attrs` mixes row-shape fields and query-param descriptors -- filter out
         # the params so they don't leak into every DAG row.

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -169,9 +169,14 @@ class StarshipAirflow(BaseStarshipAirflow):
                 "methods": [("GET", False)],
                 "test_value": "dag_0",
             },
+            "search_field": {
+                "attr": "search_field",
+                "methods": [("GET", False)],
+                "test_value": "dag_id",
+            },
         }
 
-    def get_dags(self, limit=None, offset=0, search=None):
+    def get_dags(self, limit=None, offset=0, search=None, search_field=None):
         """Get DAGs with optional pagination and search."""
         from airflow.models import DagModel, DagTag
         from sqlalchemy import distinct, func, or_, select
@@ -182,6 +187,7 @@ class StarshipAirflow(BaseStarshipAirflow):
         limit = int(limit) if limit not in (None, "") else None
         offset = int(offset) if offset not in (None, "", 0, "0") else 0
         search = search or None
+        search_field = search_field or None
 
         # `dag_attrs` mixes row-shape fields and query-param descriptors -- filter out
         # the params so they don't leak into every DAG row.
@@ -196,18 +202,19 @@ class StarshipAirflow(BaseStarshipAirflow):
 
         try:
             # Search matches dag_id, owners, or any tag (case-insensitive substring).
+            # `search_field` narrows to a single column: dag_id | owner | tag.
             def _apply_search(query):
                 if not search:
                     return query
                 pattern = f"%{search}%"
                 tag_subq = select(DagTag.dag_id).where(DagTag.name.ilike(pattern)).distinct()
-                return query.filter(
-                    or_(
-                        DagModel.dag_id.ilike(pattern),
-                        DagModel.owners.ilike(pattern),
-                        DagModel.dag_id.in_(tag_subq),
-                    )
-                )
+                field_filters = {
+                    "dag_id": DagModel.dag_id.ilike(pattern),
+                    "owner": DagModel.owners.ilike(pattern),
+                    "tag": DagModel.dag_id.in_(tag_subq),
+                }
+                clause = field_filters.get(search_field) or or_(*field_filters.values())
+                return query.filter(clause)
 
             # Total count reflects the search filter, not the page window.
             total = _apply_search(self.session.query(func.count(DagModel.dag_id))).scalar() or 0

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -213,7 +213,7 @@ class StarshipAirflow(BaseStarshipAirflow):
                     "owner": DagModel.owners.ilike(pattern),
                     "tag": DagModel.dag_id.in_(tag_subq),
                 }
-                clause = field_filters.get(search_field) or or_(*field_filters.values())
+                clause = field_filters[search_field] if search_field in field_filters else or_(*field_filters.values())
                 return query.filter(clause)
 
             # Total count reflects the search filter, not the page window.

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -153,41 +153,113 @@ class StarshipAirflow(BaseStarshipAirflow):
                 "methods": [],
                 "test_value": 0,
             },
+            # Pagination and search are query params on GET, not row fields.
+            "limit": {
+                "attr": "limit",
+                "methods": [("GET", False)],
+                "test_value": 50,
+            },
+            "offset": {
+                "attr": "offset",
+                "methods": [("GET", False)],
+                "test_value": 0,
+            },
+            "search": {
+                "attr": "search",
+                "methods": [("GET", False)],
+                "test_value": "dag_0",
+            },
         }
 
-    def get_dags(self):
-        """Get all DAGs"""
-        from airflow.models import DagModel
+    def get_dags(self, limit=None, offset=0, search=None):
+        """Get DAGs with optional pagination and search."""
+        from airflow.models import DagModel, DagTag
+        from sqlalchemy import distinct, func, or_, select
+        from sqlalchemy.sql.functions import count
+
+        # Query params come in as strings via request.args; coerce.
+        limit = int(limit) if limit is not None else None
+        offset = int(offset) if offset else 0
+
+        # `dag_attrs` mixes row-shape fields and query-param descriptors -- filter out
+        # the params so they don't leak into every DAG row.
+        row_attrs = {
+            attr: desc
+            for attr, desc in self.dag_attrs().items()
+            if not (desc["methods"] and all(m[0] == "GET" for m in desc["methods"]))
+        }
+        fields = [
+            getattr(DagModel, attr_desc["attr"]) for attr_desc in row_attrs.values() if attr_desc["attr"] is not None
+        ]
 
         try:
-            fields = [
-                getattr(DagModel, attr_desc["attr"])
-                for attr_desc in self.dag_attrs().values()
-                if attr_desc["attr"] is not None
-            ]
-            # py36/sqlalchemy1.3 doesn't like label?
-            # noinspection PyUnresolvedReferences
-            return json.loads(
+            # Search matches dag_id, owners, or any tag (case-insensitive substring).
+            def _apply_search(query):
+                if not search:
+                    return query
+                pattern = f"%{search}%"
+                tag_subq = select(DagTag.dag_id).where(DagTag.name.ilike(pattern)).distinct()
+                return query.filter(
+                    or_(
+                        DagModel.dag_id.ilike(pattern),
+                        DagModel.owners.ilike(pattern),
+                        DagModel.dag_id.in_(tag_subq),
+                    )
+                )
+
+            # Total count reflects the search filter, not the page window.
+            total = _apply_search(self.session.query(func.count(DagModel.dag_id))).scalar() or 0
+
+            page_query = _apply_search(self.session.query(*fields)).order_by(DagModel.dag_id)
+            if offset:
+                page_query = page_query.offset(offset)
+            if limit is not None:
+                page_query = page_query.limit(limit)
+            page = page_query.all()
+            page_dag_ids = [row.dag_id for row in page]
+
+            # Batched tag lookup: one query instead of N.
+            # noqa comprehension (not `dict.fromkeys`) is intentional: each value is a fresh list.
+            tags_by_dag = {dag_id: [] for dag_id in page_dag_ids}  # noqa: C420
+            if page_dag_ids:
+                for dag_id, tag_name in self.session.query(DagTag.dag_id, DagTag.name).filter(
+                    DagTag.dag_id.in_(page_dag_ids)
+                ):
+                    tags_by_dag[dag_id].append(tag_name)
+
+            # Batched run count: one grouped query instead of N.
+            from airflow.models import DagRun
+
+            counts_by_dag = dict.fromkeys(page_dag_ids, 0)
+            if page_dag_ids:
+                for dag_id, run_count in (
+                    self.session.query(DagRun.dag_id, count(distinct(DagRun.run_id)))
+                    .filter(DagRun.dag_id.in_(page_dag_ids))
+                    .group_by(DagRun.dag_id)
+                ):
+                    counts_by_dag[dag_id] = run_count
+
+            dags = json.loads(
                 json.dumps(
                     [
                         {
                             attr: (
-                                self._get_tags(result.dag_id)
+                                tags_by_dag.get(result.dag_id, [])
                                 if attr == "tags"
                                 else (
-                                    self._get_dag_run_count(result.dag_id)
+                                    counts_by_dag.get(result.dag_id, 0)
                                     if attr == "dag_run_count"
                                     else getattr(result, attr_desc["attr"], None)
                                 )
-                                # e.g. result.dag_id
                             )
-                            for attr, attr_desc in self.dag_attrs().items()
+                            for attr, attr_desc in row_attrs.items()
                         }
-                        for result in self.session.query(*fields).all()
+                        for result in page
                     ],
                     default=str,
                 )
             )
+            return {"dags": dags, "total_dag_count": total}
         except Exception as e:
             self.session.rollback()
             raise e

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -179,7 +179,7 @@ class StarshipAirflow(BaseStarshipAirflow):
     def get_dags(self, limit=None, offset=0, search=None, search_field=None):
         """Get DAGs with optional pagination and search."""
         from airflow.models import DagModel, DagTag
-        from sqlalchemy import distinct, func, or_, select
+        from sqlalchemy import distinct, func, or_
         from sqlalchemy.sql.functions import count
 
         # Query params come in as strings via request.args; coerce.
@@ -207,7 +207,9 @@ class StarshipAirflow(BaseStarshipAirflow):
                 if not search:
                     return query
                 pattern = f"%{search}%"
-                tag_subq = select(DagTag.dag_id).where(DagTag.name.ilike(pattern)).distinct()
+                # session.query subquery form is portable across SQLAlchemy 1.3/1.4/2.x;
+                # the newer `select(col)` short form is 1.4+ only.
+                tag_subq = self.session.query(DagTag.dag_id).filter(DagTag.name.ilike(pattern)).distinct()
                 field_filters = {
                     "dag_id": DagModel.dag_id.ilike(pattern),
                     "owner": DagModel.owners.ilike(pattern),

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -196,8 +196,8 @@ class StarshipAirflow(BaseStarshipAirflow):
         single queries per page (see :meth:`_fetch_tags_by_dag_id` and
         :meth:`_fetch_dag_run_counts`) to avoid N+1.
         """
-        from airflow.models import DagModel, DagTag
-        from sqlalchemy import func, or_
+        from airflow.models import DagModel
+        from sqlalchemy import func
 
         # Query params come in as strings via request.args; coerce.
         # Treat empty strings as unset (e.g. `?limit=&offset=`) and silently
@@ -214,27 +214,15 @@ class StarshipAirflow(BaseStarshipAirflow):
         ]
 
         try:
-            # Search matches dag_id, owners, or any tag (case-insensitive substring).
-            # `search_field` narrows to a single column: dag_id | owner | tag.
-            def _apply_search(query):
-                if not search:
-                    return query
-                pattern = f"%{search}%"
-                # session.query subquery form is portable across SQLAlchemy 1.3/1.4/2.x;
-                # the newer `select(col)` short form is 1.4+ only.
-                tag_subq = self.session.query(DagTag.dag_id).filter(DagTag.name.ilike(pattern)).distinct()
-                field_filters = {
-                    "dag_id": DagModel.dag_id.ilike(pattern),
-                    "owner": DagModel.owners.ilike(pattern),
-                    "tag": DagModel.dag_id.in_(tag_subq),
-                }
-                clause = field_filters[search_field] if search_field in field_filters else or_(*field_filters.values())
-                return query.filter(clause)
-
             # Total count reflects the search filter, not the page window.
-            total = _apply_search(self.session.query(func.count(DagModel.dag_id))).scalar() or 0
+            total = (
+                self._search_dag_query(self.session.query(func.count(DagModel.dag_id)), search, search_field).scalar()
+                or 0
+            )
 
-            page_query = _apply_search(self.session.query(*fields)).order_by(DagModel.dag_id)
+            page_query = self._search_dag_query(self.session.query(*fields), search, search_field).order_by(
+                DagModel.dag_id
+            )
             if offset:
                 page_query = page_query.offset(offset)
             if limit is not None:

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import logging
 import os
+from collections import defaultdict
 from datetime import timezone
 from typing import TYPE_CHECKING
 
@@ -10,6 +11,7 @@ from astronomer_starship.common import (
     ConflictError,
     NotFoundError,
     generic_delete,
+    nonneg_int,
     results_to_list_via_attrs,
 )
 
@@ -20,17 +22,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-def _nonneg_int(value, default):
-    """Return `value` coerced to a non-negative int, or `default` on bad input."""
-    if value in (None, ""):
-        return default
-    try:
-        n = int(value)
-    except (TypeError, ValueError):
-        return default
-    return max(n, 0)
 
 
 class StarshipAirflow(BaseStarshipAirflow):
@@ -197,8 +188,8 @@ class StarshipAirflow(BaseStarshipAirflow):
         # Treat empty strings as unset (e.g. `?limit=&offset=`) and silently
         # clamp non-int / negative values to safe defaults so bad input yields
         # a well-formed empty response instead of a 500.
-        limit = _nonneg_int(limit, default=None)
-        offset = _nonneg_int(offset, default=0)
+        limit = nonneg_int(limit, default=None)
+        offset = nonneg_int(offset, default=0)
         search = search or None
         search_field = search_field or None
 
@@ -243,8 +234,7 @@ class StarshipAirflow(BaseStarshipAirflow):
             page_dag_ids = [row.dag_id for row in page]
 
             # Batched tag lookup: one query instead of N.
-            # noqa comprehension (not `dict.fromkeys`) is intentional: each value is a fresh list.
-            tags_by_dag = {dag_id: [] for dag_id in page_dag_ids}  # noqa: C420
+            tags_by_dag = defaultdict(list)
             if page_dag_ids:
                 for dag_id, tag_name in self.session.query(DagTag.dag_id, DagTag.name).filter(
                     DagTag.dag_id.in_(page_dag_ids)

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -13,6 +13,7 @@ from astronomer_starship.common import (
     generic_delete,
     nonneg_int,
     results_to_list_via_attrs,
+    row_shape_attrs,
 )
 
 if TYPE_CHECKING:
@@ -193,13 +194,7 @@ class StarshipAirflow(BaseStarshipAirflow):
         search = search or None
         search_field = search_field or None
 
-        # `dag_attrs` mixes row-shape fields and query-param descriptors -- filter out
-        # the params so they don't leak into every DAG row.
-        row_attrs = {
-            attr: desc
-            for attr, desc in self.dag_attrs().items()
-            if not (desc["methods"] and all(m[0] == "GET" for m in desc["methods"]))
-        }
+        row_attrs = row_shape_attrs(self.dag_attrs())
         fields = [
             getattr(DagModel, attr_desc["attr"]) for attr_desc in row_attrs.values() if attr_desc["attr"] is not None
         ]

--- a/astronomer_starship/_af2/starship_compatability.py
+++ b/astronomer_starship/_af2/starship_compatability.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import logging
 import os
-from collections import defaultdict
 from datetime import timezone
 from typing import TYPE_CHECKING
 
@@ -180,10 +179,25 @@ class StarshipAirflow(BaseStarshipAirflow):
         }
 
     def get_dags(self, limit=None, offset=0, search=None, search_field=None):
-        """Get DAGs with optional pagination and search."""
+        """Return a page of DAGs with optional filtering.
+
+        :param limit: max rows to return; ``None`` (or empty/invalid) means
+            no limit.
+        :param offset: number of rows to skip; invalid values coerce to 0.
+        :param search: case-insensitive substring; matches ``dag_id``,
+            ``owners``, or any tag.
+        :param search_field: narrow the match to one of ``"dag_id"``,
+            ``"owner"``, or ``"tag"``. Unset means match against all three.
+        :returns: ``{"dags": [...page rows...], "total_dag_count": N}``
+            where ``N`` reflects the search filter (not the page window).
+
+        Query params are coerced defensively -- bad input yields an empty
+        response instead of a 500. Tag and DAG-run counts are batched into
+        single queries per page (see :meth:`_fetch_tags_by_dag_id` and
+        :meth:`_fetch_dag_run_counts`) to avoid N+1.
+        """
         from airflow.models import DagModel, DagTag
-        from sqlalchemy import distinct, func, or_
-        from sqlalchemy.sql.functions import count
+        from sqlalchemy import func, or_
 
         # Query params come in as strings via request.args; coerce.
         # Treat empty strings as unset (e.g. `?limit=&offset=`) and silently
@@ -228,25 +242,8 @@ class StarshipAirflow(BaseStarshipAirflow):
             page = page_query.all()
             page_dag_ids = [row.dag_id for row in page]
 
-            # Batched tag lookup: one query instead of N.
-            tags_by_dag = defaultdict(list)
-            if page_dag_ids:
-                for dag_id, tag_name in self.session.query(DagTag.dag_id, DagTag.name).filter(
-                    DagTag.dag_id.in_(page_dag_ids)
-                ):
-                    tags_by_dag[dag_id].append(tag_name)
-
-            # Batched run count: one grouped query instead of N.
-            from airflow.models import DagRun
-
-            counts_by_dag = dict.fromkeys(page_dag_ids, 0)
-            if page_dag_ids:
-                for dag_id, run_count in (
-                    self.session.query(DagRun.dag_id, count(distinct(DagRun.run_id)))
-                    .filter(DagRun.dag_id.in_(page_dag_ids))
-                    .group_by(DagRun.dag_id)
-                ):
-                    counts_by_dag[dag_id] = run_count
+            tags_by_dag = self._fetch_tags_by_dag_id(page_dag_ids)
+            counts_by_dag = self._fetch_dag_run_counts(page_dag_ids)
 
             dags = json.loads(
                 json.dumps(

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -19,6 +19,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _nonneg_int(value, default):
+    """Return `value` coerced to a non-negative int, or `default` on bad input."""
+    if value in (None, ""):
+        return default
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(n, 0)
+
+
 class StarshipAirflow(BaseStarshipAirflow):
     """Base class for Airflow 3.x compatibility layers.
 
@@ -188,9 +199,11 @@ class StarshipAirflow30(StarshipAirflow):
         from sqlalchemy.sql.functions import count
 
         # Query params come in as strings via request.args; coerce.
-        # Treat empty strings as unset (e.g. `?limit=&offset=`).
-        limit = int(limit) if limit not in (None, "") else None
-        offset = int(offset) if offset not in (None, "", 0, "0") else 0
+        # Treat empty strings as unset (e.g. `?limit=&offset=`) and silently
+        # clamp non-int / negative values to safe defaults so bad input yields
+        # a well-formed empty response instead of a 500.
+        limit = _nonneg_int(limit, default=None)
+        offset = _nonneg_int(offset, default=0)
         search = search or None
         search_field = search_field or None
 

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -183,8 +183,10 @@ class StarshipAirflow30(StarshipAirflow):
         from sqlalchemy.sql.functions import count
 
         # Query params come in as strings via request.args; coerce.
-        limit = int(limit) if limit is not None else None
-        offset = int(offset) if offset else 0
+        # Treat empty strings as unset (e.g. `?limit=&offset=`).
+        limit = int(limit) if limit not in (None, "") else None
+        offset = int(offset) if offset not in (None, "", 0, "0") else 0
+        search = search or None
 
         # `dag_attrs` mixes row-shape fields and query-param descriptors -- filter out
         # the params so they don't leak into every DAG row.

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -159,38 +159,112 @@ class StarshipAirflow30(StarshipAirflow):
                 "methods": [],
                 "test_value": 0,
             },
+            # Pagination and search are query params on GET, not row fields.
+            "limit": {
+                "attr": "limit",
+                "methods": [("GET", False)],
+                "test_value": 50,
+            },
+            "offset": {
+                "attr": "offset",
+                "methods": [("GET", False)],
+                "test_value": 0,
+            },
+            "search": {
+                "attr": "search",
+                "methods": [("GET", False)],
+                "test_value": "dag_0",
+            },
         }
 
-    def get_dags(self):
-        from airflow.models import DagModel
+    def get_dags(self, limit=None, offset=0, search=None):
+        from airflow.models import DagModel, DagTag
+        from sqlalchemy import distinct, func, or_, select
+        from sqlalchemy.sql.functions import count
+
+        # Query params come in as strings via request.args; coerce.
+        limit = int(limit) if limit is not None else None
+        offset = int(offset) if offset else 0
+
+        # `dag_attrs` mixes row-shape fields and query-param descriptors -- filter out
+        # the params so they don't leak into every DAG row.
+        row_attrs = {
+            attr: desc
+            for attr, desc in self.dag_attrs().items()
+            if not (desc["methods"] and all(m[0] == "GET" for m in desc["methods"]))
+        }
+        fields = [
+            getattr(DagModel, attr_desc["attr"]) for attr_desc in row_attrs.values() if attr_desc["attr"] is not None
+        ]
 
         try:
-            fields = [
-                getattr(DagModel, attr_desc["attr"])
-                for attr_desc in self.dag_attrs().values()
-                if attr_desc["attr"] is not None
-            ]
+            # Search matches dag_id, owners, or any tag (case-insensitive substring).
+            def _apply_search(query):
+                if not search:
+                    return query
+                pattern = f"%{search}%"
+                tag_subq = select(DagTag.dag_id).where(DagTag.name.ilike(pattern)).distinct()
+                return query.filter(
+                    or_(
+                        DagModel.dag_id.ilike(pattern),
+                        DagModel.owners.ilike(pattern),
+                        DagModel.dag_id.in_(tag_subq),
+                    )
+                )
 
-            return json.loads(
+            # Total count reflects the search filter, not the page window.
+            total = _apply_search(self.session.query(func.count(DagModel.dag_id))).scalar() or 0
+
+            page_query = _apply_search(self.session.query(*fields)).order_by(DagModel.dag_id)
+            if offset:
+                page_query = page_query.offset(offset)
+            if limit is not None:
+                page_query = page_query.limit(limit)
+            page = page_query.all()
+            page_dag_ids = [row.dag_id for row in page]
+
+            # Batched tag lookup: one query instead of N.
+            # noqa comprehension (not `dict.fromkeys`) is intentional: each value is a fresh list.
+            tags_by_dag = {dag_id: [] for dag_id in page_dag_ids}  # noqa: C420
+            if page_dag_ids:
+                for dag_id, tag_name in self.session.query(DagTag.dag_id, DagTag.name).filter(
+                    DagTag.dag_id.in_(page_dag_ids)
+                ):
+                    tags_by_dag[dag_id].append(tag_name)
+
+            # Batched run count: one grouped query instead of N.
+            from airflow.models import DagRun
+
+            counts_by_dag = dict.fromkeys(page_dag_ids, 0)
+            if page_dag_ids:
+                for dag_id, run_count in (
+                    self.session.query(DagRun.dag_id, count(distinct(DagRun.run_id)))
+                    .filter(DagRun.dag_id.in_(page_dag_ids))
+                    .group_by(DagRun.dag_id)
+                ):
+                    counts_by_dag[dag_id] = run_count
+
+            dags = json.loads(
                 json.dumps(
                     [
                         {
                             attr: (
-                                self._get_tags(result.dag_id)
+                                tags_by_dag.get(result.dag_id, [])
                                 if attr == "tags"
                                 else (
-                                    self._get_dag_run_count(result.dag_id)
+                                    counts_by_dag.get(result.dag_id, 0)
                                     if attr == "dag_run_count"
                                     else getattr(result, attr_desc["attr"], None)
                                 )
                             )
-                            for attr, attr_desc in self.dag_attrs().items()
+                            for attr, attr_desc in row_attrs.items()
                         }
-                        for result in self.session.query(*fields).all()
+                        for result in page
                     ],
                     default=str,
                 )
             )
+            return {"dags": dags, "total_dag_count": total}
         except Exception as e:
             self.session.rollback()
             raise e

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -175,9 +175,14 @@ class StarshipAirflow30(StarshipAirflow):
                 "methods": [("GET", False)],
                 "test_value": "dag_0",
             },
+            "search_field": {
+                "attr": "search_field",
+                "methods": [("GET", False)],
+                "test_value": "dag_id",
+            },
         }
 
-    def get_dags(self, limit=None, offset=0, search=None):
+    def get_dags(self, limit=None, offset=0, search=None, search_field=None):
         from airflow.models import DagModel, DagTag
         from sqlalchemy import distinct, func, or_, select
         from sqlalchemy.sql.functions import count
@@ -187,6 +192,7 @@ class StarshipAirflow30(StarshipAirflow):
         limit = int(limit) if limit not in (None, "") else None
         offset = int(offset) if offset not in (None, "", 0, "0") else 0
         search = search or None
+        search_field = search_field or None
 
         # `dag_attrs` mixes row-shape fields and query-param descriptors -- filter out
         # the params so they don't leak into every DAG row.
@@ -201,18 +207,19 @@ class StarshipAirflow30(StarshipAirflow):
 
         try:
             # Search matches dag_id, owners, or any tag (case-insensitive substring).
+            # `search_field` narrows to a single column: dag_id | owner | tag.
             def _apply_search(query):
                 if not search:
                     return query
                 pattern = f"%{search}%"
                 tag_subq = select(DagTag.dag_id).where(DagTag.name.ilike(pattern)).distinct()
-                return query.filter(
-                    or_(
-                        DagModel.dag_id.ilike(pattern),
-                        DagModel.owners.ilike(pattern),
-                        DagModel.dag_id.in_(tag_subq),
-                    )
-                )
+                field_filters = {
+                    "dag_id": DagModel.dag_id.ilike(pattern),
+                    "owner": DagModel.owners.ilike(pattern),
+                    "tag": DagModel.dag_id.in_(tag_subq),
+                }
+                clause = field_filters.get(search_field) or or_(*field_filters.values())
+                return query.filter(clause)
 
             # Total count reflects the search filter, not the page window.
             total = _apply_search(self.session.query(func.count(DagModel.dag_id))).scalar() or 0

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -184,7 +184,7 @@ class StarshipAirflow30(StarshipAirflow):
 
     def get_dags(self, limit=None, offset=0, search=None, search_field=None):
         from airflow.models import DagModel, DagTag
-        from sqlalchemy import distinct, func, or_, select
+        from sqlalchemy import distinct, func, or_
         from sqlalchemy.sql.functions import count
 
         # Query params come in as strings via request.args; coerce.
@@ -212,7 +212,9 @@ class StarshipAirflow30(StarshipAirflow):
                 if not search:
                     return query
                 pattern = f"%{search}%"
-                tag_subq = select(DagTag.dag_id).where(DagTag.name.ilike(pattern)).distinct()
+                # session.query subquery form is portable across SQLAlchemy 1.3/1.4/2.x;
+                # the newer `select(col)` short form is 1.4+ only.
+                tag_subq = self.session.query(DagTag.dag_id).filter(DagTag.name.ilike(pattern)).distinct()
                 field_filters = {
                     "dag_id": DagModel.dag_id.ilike(pattern),
                     "owner": DagModel.owners.ilike(pattern),

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -218,7 +218,7 @@ class StarshipAirflow30(StarshipAirflow):
                     "owner": DagModel.owners.ilike(pattern),
                     "tag": DagModel.dag_id.in_(tag_subq),
                 }
-                clause = field_filters.get(search_field) or or_(*field_filters.values())
+                clause = field_filters[search_field] if search_field in field_filters else or_(*field_filters.values())
                 return query.filter(clause)
 
             # Total count reflects the search filter, not the page window.

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -10,6 +10,7 @@ from astronomer_starship.common import (
     generic_delete,
     nonneg_int,
     results_to_list_via_attrs,
+    row_shape_attrs,
 )
 
 if TYPE_CHECKING:
@@ -198,13 +199,7 @@ class StarshipAirflow30(StarshipAirflow):
         search = search or None
         search_field = search_field or None
 
-        # `dag_attrs` mixes row-shape fields and query-param descriptors -- filter out
-        # the params so they don't leak into every DAG row.
-        row_attrs = {
-            attr: desc
-            for attr, desc in self.dag_attrs().items()
-            if not (desc["methods"] and all(m[0] == "GET" for m in desc["methods"]))
-        }
+        row_attrs = row_shape_attrs(self.dag_attrs())
         fields = [
             getattr(DagModel, attr_desc["attr"]) for attr_desc in row_attrs.values() if attr_desc["attr"] is not None
         ]

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import logging
-from collections import defaultdict
 from datetime import timezone
 from typing import TYPE_CHECKING
 
@@ -186,9 +185,25 @@ class StarshipAirflow30(StarshipAirflow):
         }
 
     def get_dags(self, limit=None, offset=0, search=None, search_field=None):
+        """Return a page of DAGs with optional filtering.
+
+        :param limit: max rows to return; ``None`` (or empty/invalid) means
+            no limit.
+        :param offset: number of rows to skip; invalid values coerce to 0.
+        :param search: case-insensitive substring; matches ``dag_id``,
+            ``owners``, or any tag.
+        :param search_field: narrow the match to one of ``"dag_id"``,
+            ``"owner"``, or ``"tag"``. Unset means match against all three.
+        :returns: ``{"dags": [...page rows...], "total_dag_count": N}``
+            where ``N`` reflects the search filter (not the page window).
+
+        Query params are coerced defensively -- bad input yields an empty
+        response instead of a 500. Tag and DAG-run counts are batched into
+        single queries per page (see :meth:`_fetch_tags_by_dag_id` and
+        :meth:`_fetch_dag_run_counts`) to avoid N+1.
+        """
         from airflow.models import DagModel, DagTag
-        from sqlalchemy import distinct, func, or_
-        from sqlalchemy.sql.functions import count
+        from sqlalchemy import func, or_
 
         # Query params come in as strings via request.args; coerce.
         # Treat empty strings as unset (e.g. `?limit=&offset=`) and silently
@@ -233,25 +248,8 @@ class StarshipAirflow30(StarshipAirflow):
             page = page_query.all()
             page_dag_ids = [row.dag_id for row in page]
 
-            # Batched tag lookup: one query instead of N.
-            tags_by_dag = defaultdict(list)
-            if page_dag_ids:
-                for dag_id, tag_name in self.session.query(DagTag.dag_id, DagTag.name).filter(
-                    DagTag.dag_id.in_(page_dag_ids)
-                ):
-                    tags_by_dag[dag_id].append(tag_name)
-
-            # Batched run count: one grouped query instead of N.
-            from airflow.models import DagRun
-
-            counts_by_dag = dict.fromkeys(page_dag_ids, 0)
-            if page_dag_ids:
-                for dag_id, run_count in (
-                    self.session.query(DagRun.dag_id, count(distinct(DagRun.run_id)))
-                    .filter(DagRun.dag_id.in_(page_dag_ids))
-                    .group_by(DagRun.dag_id)
-                ):
-                    counts_by_dag[dag_id] = run_count
+            tags_by_dag = self._fetch_tags_by_dag_id(page_dag_ids)
+            counts_by_dag = self._fetch_dag_run_counts(page_dag_ids)
 
             dags = json.loads(
                 json.dumps(

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -202,8 +202,8 @@ class StarshipAirflow30(StarshipAirflow):
         single queries per page (see :meth:`_fetch_tags_by_dag_id` and
         :meth:`_fetch_dag_run_counts`) to avoid N+1.
         """
-        from airflow.models import DagModel, DagTag
-        from sqlalchemy import func, or_
+        from airflow.models import DagModel
+        from sqlalchemy import func
 
         # Query params come in as strings via request.args; coerce.
         # Treat empty strings as unset (e.g. `?limit=&offset=`) and silently
@@ -220,27 +220,15 @@ class StarshipAirflow30(StarshipAirflow):
         ]
 
         try:
-            # Search matches dag_id, owners, or any tag (case-insensitive substring).
-            # `search_field` narrows to a single column: dag_id | owner | tag.
-            def _apply_search(query):
-                if not search:
-                    return query
-                pattern = f"%{search}%"
-                # session.query subquery form is portable across SQLAlchemy 1.3/1.4/2.x;
-                # the newer `select(col)` short form is 1.4+ only.
-                tag_subq = self.session.query(DagTag.dag_id).filter(DagTag.name.ilike(pattern)).distinct()
-                field_filters = {
-                    "dag_id": DagModel.dag_id.ilike(pattern),
-                    "owner": DagModel.owners.ilike(pattern),
-                    "tag": DagModel.dag_id.in_(tag_subq),
-                }
-                clause = field_filters[search_field] if search_field in field_filters else or_(*field_filters.values())
-                return query.filter(clause)
-
             # Total count reflects the search filter, not the page window.
-            total = _apply_search(self.session.query(func.count(DagModel.dag_id))).scalar() or 0
+            total = (
+                self._search_dag_query(self.session.query(func.count(DagModel.dag_id)), search, search_field).scalar()
+                or 0
+            )
 
-            page_query = _apply_search(self.session.query(*fields)).order_by(DagModel.dag_id)
+            page_query = self._search_dag_query(self.session.query(*fields), search, search_field).order_by(
+                DagModel.dag_id
+            )
             if offset:
                 page_query = page_query.offset(offset)
             if limit is not None:

--- a/astronomer_starship/_af3/starship_compatability.py
+++ b/astronomer_starship/_af3/starship_compatability.py
@@ -1,12 +1,14 @@
 import datetime
 import json
 import logging
+from collections import defaultdict
 from datetime import timezone
 from typing import TYPE_CHECKING
 
 from astronomer_starship.common import (
     BaseStarshipAirflow,
     generic_delete,
+    nonneg_int,
     results_to_list_via_attrs,
 )
 
@@ -17,17 +19,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-def _nonneg_int(value, default):
-    """Return `value` coerced to a non-negative int, or `default` on bad input."""
-    if value in (None, ""):
-        return default
-    try:
-        n = int(value)
-    except (TypeError, ValueError):
-        return default
-    return max(n, 0)
 
 
 class StarshipAirflow(BaseStarshipAirflow):
@@ -202,8 +193,8 @@ class StarshipAirflow30(StarshipAirflow):
         # Treat empty strings as unset (e.g. `?limit=&offset=`) and silently
         # clamp non-int / negative values to safe defaults so bad input yields
         # a well-formed empty response instead of a 500.
-        limit = _nonneg_int(limit, default=None)
-        offset = _nonneg_int(offset, default=0)
+        limit = nonneg_int(limit, default=None)
+        offset = nonneg_int(offset, default=0)
         search = search or None
         search_field = search_field or None
 
@@ -248,8 +239,7 @@ class StarshipAirflow30(StarshipAirflow):
             page_dag_ids = [row.dag_id for row in page]
 
             # Batched tag lookup: one query instead of N.
-            # noqa comprehension (not `dict.fromkeys`) is intentional: each value is a fresh list.
-            tags_by_dag = {dag_id: [] for dag_id in page_dag_ids}  # noqa: C420
+            tags_by_dag = defaultdict(list)
             if page_dag_ids:
                 for dag_id, tag_name in self.session.query(DagTag.dag_id, DagTag.name).filter(
                     DagTag.dag_id.in_(page_dag_ids)

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -53,6 +53,17 @@ class ConflictError(HttpError):
         super().__init__(msg, 409)
 
 
+def nonneg_int(value, default):
+    """Return `value` coerced to a non-negative int, or `default` on bad input."""
+    if value in (None, ""):
+        return default
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(n, 0)
+
+
 def get_json_or_clean_str(o: str) -> Union[List[Any], Dict[Any, Any], Any]:
     """For Aeroscope - Either load JSON (if we can) or strip and split the string, while logging the error"""
     import logging

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -456,6 +456,32 @@ class BaseStarshipAirflow:
             counts_by_dag[dag_id] = run_count
         return counts_by_dag
 
+    def _search_dag_query(self, query, search, search_field):
+        """Apply the DAG search filter to a DagModel-based query.
+
+        ``search`` is a case-insensitive substring matched against
+        ``dag_id``, ``owners``, or any tag. ``search_field`` narrows the
+        match to one of ``"dag_id"``, ``"owner"``, or ``"tag"``; unset (or
+        any other value) matches against all three. A falsy ``search``
+        returns ``query`` unchanged.
+        """
+        from airflow.models import DagModel, DagTag
+        from sqlalchemy import or_
+
+        if not search:
+            return query
+        pattern = f"%{search}%"
+        # session.query subquery form is portable across SQLAlchemy 1.3/1.4/2.x;
+        # the newer `select(col)` short form is 1.4+ only.
+        tag_subq = self.session.query(DagTag.dag_id).filter(DagTag.name.ilike(pattern)).distinct()
+        field_filters = {
+            "dag_id": DagModel.dag_id.ilike(pattern),
+            "owner": DagModel.owners.ilike(pattern),
+            "tag": DagModel.dag_id.in_(tag_subq),
+        }
+        clause = field_filters[search_field] if search_field in field_filters else or_(*field_filters.values())
+        return query.filter(clause)
+
     @classmethod
     def pool_attrs(cls) -> "Dict[str, AttrDesc]":
         raise NotImplementedError("Subclasses must implement pool_attrs method")

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -64,6 +64,31 @@ def nonneg_int(value, default):
     return max(n, 0)
 
 
+def row_shape_attrs(attrs):
+    """Pick just the row fields out of an ``*_attrs()`` dict.
+
+    Each ``*_attrs()`` dict does two jobs: it describes the columns we return
+    in a response row, and it also lists the query params we accept on a GET
+    request (``limit``, ``offset``, ``search``, etc.). The query-param entries
+    are tagged as GET-only; everything else is a real row field. When we're
+    building rows we only want the row fields, so we drop the GET-only ones.
+
+    >>> row_shape_attrs(
+    ...     {
+    ...         "dag_id": {"attr": "dag_id", "methods": [("PATCH", True)]},
+    ...         "owners": {"attr": "owners", "methods": []},
+    ...         "limit": {"attr": None, "methods": [("GET", False)]},
+    ...     }
+    ... )  # doctest: +ELLIPSIS
+    {'dag_id': {...}, 'owners': {...}}
+    """
+    return {
+        attr: desc
+        for attr, desc in attrs.items()
+        if not (desc["methods"] and all(m[0] == "GET" for m in desc["methods"]))
+    }
+
+
 def get_json_or_clean_str(o: str) -> Union[List[Any], Dict[Any, Any], Any]:
     """For Aeroscope - Either load JSON (if we can) or strip and split the string, while logging the error"""
     import logging

--- a/astronomer_starship/common.py
+++ b/astronomer_starship/common.py
@@ -418,6 +418,44 @@ class BaseStarshipAirflow:
     def get_env_vars(cls):
         return dict(os.environ)
 
+    def _fetch_tags_by_dag_id(self, dag_ids: list) -> Dict[str, List[str]]:
+        """Return ``{dag_id: [tag_name, ...]}`` for the given dag_ids.
+
+        Fetches all tags for the requested DAGs in a single query to avoid an
+        N+1 pattern when serializing a page of DAGs.
+        """
+        from collections import defaultdict
+
+        from airflow.models import DagTag
+
+        tags_by_dag: Dict[str, List[str]] = defaultdict(list)
+        if not dag_ids:
+            return tags_by_dag
+        for dag_id, tag_name in self.session.query(DagTag.dag_id, DagTag.name).filter(DagTag.dag_id.in_(dag_ids)):
+            tags_by_dag[dag_id].append(tag_name)
+        return tags_by_dag
+
+    def _fetch_dag_run_counts(self, dag_ids: list) -> Dict[str, int]:
+        """Return ``{dag_id: run_count}`` for the given dag_ids.
+
+        Missing dag_ids (no DAG runs) are included with a count of 0. Fetches
+        all counts in a single ``GROUP BY`` query to avoid an N+1 pattern.
+        """
+        from airflow.models import DagRun
+        from sqlalchemy import distinct
+        from sqlalchemy.sql.functions import count
+
+        counts_by_dag: Dict[str, int] = dict.fromkeys(dag_ids, 0)
+        if not dag_ids:
+            return counts_by_dag
+        for dag_id, run_count in (
+            self.session.query(DagRun.dag_id, count(distinct(DagRun.run_id)))
+            .filter(DagRun.dag_id.in_(dag_ids))
+            .group_by(DagRun.dag_id)
+        ):
+            counts_by_dag[dag_id] = run_count
+        return counts_by_dag
+
     @classmethod
     def pool_attrs(cls) -> "Dict[str, AttrDesc]":
         raise NotImplementedError("Subclasses must implement pool_attrs method")

--- a/astronomer_starship/providers/starship/operators/starship.py
+++ b/astronomer_starship/providers/starship/operators/starship.py
@@ -232,6 +232,9 @@ def starship_dag_history_migration(dag_ids: List[str] = None, **kwargs):
         @task()
         def get_dags():
             _dags = StarshipLocalHook().get_dags()
+            # `get_dags` returns {"dags": [...], "total_dag_count": N}; older releases returned a bare list.
+            if isinstance(_dags, dict):
+                _dags = _dags.get("dags", [])
             _dags = (
                 [k["dag_id"] for k in _dags if k["dag_id"] in dag_ids and k["dag_id"] != "StarshipAirflowMigrationDAG"]
                 if dag_ids is not None

--- a/astronomer_starship/src/AppContext.jsx
+++ b/astronomer_starship/src/AppContext.jsx
@@ -36,6 +36,12 @@ const initialState = {
   limit: 100,
   batchSize: 10,
 
+  // DAG History pagination
+  dagHistoryPage: 0,
+  dagHistoryPageSize: 50,
+  dagHistorySearch: '',
+  dagHistoryUnmigratedOnly: false,
+
   // Local Airflow info
   localAirflowVersion: null,
 };
@@ -109,6 +115,15 @@ function reducer(state, action) {
       return { ...state, limit: action.limit };
     case 'set-batch-size':
       return { ...state, batchSize: action.batchSize };
+    case 'set-dag-history-page':
+      return { ...state, dagHistoryPage: action.page };
+    case 'set-dag-history-page-size':
+      // Reset to page 0 when page size changes so offsets stay valid.
+      return { ...state, dagHistoryPageSize: action.pageSize, dagHistoryPage: 0 };
+    case 'set-dag-history-search':
+      return { ...state, dagHistorySearch: action.search, dagHistoryPage: 0 };
+    case 'set-dag-history-unmigrated-only':
+      return { ...state, dagHistoryUnmigratedOnly: action.unmigratedOnly };
     case 'set-local-airflow-version':
       return { ...state, localAirflowVersion: action.version };
     case 'reset':
@@ -229,8 +244,19 @@ export function useDagHistoryConfig() {
     () => ({
       limit: state.limit,
       batchSize: state.batchSize,
+      page: state.dagHistoryPage,
+      pageSize: state.dagHistoryPageSize,
+      search: state.dagHistorySearch,
+      unmigratedOnly: state.dagHistoryUnmigratedOnly,
     }),
-    [state.limit, state.batchSize],
+    [
+      state.limit,
+      state.batchSize,
+      state.dagHistoryPage,
+      state.dagHistoryPageSize,
+      state.dagHistorySearch,
+      state.dagHistoryUnmigratedOnly,
+    ],
   );
 }
 

--- a/astronomer_starship/src/AppContext.jsx
+++ b/astronomer_starship/src/AppContext.jsx
@@ -40,7 +40,6 @@ const initialState = {
   dagHistoryPage: 0,
   dagHistoryPageSize: 50,
   dagHistorySearch: '',
-  dagHistoryUnmigratedOnly: false,
 
   // Local Airflow info
   localAirflowVersion: null,
@@ -122,8 +121,6 @@ function reducer(state, action) {
       return { ...state, dagHistoryPageSize: action.pageSize, dagHistoryPage: 0 };
     case 'set-dag-history-search':
       return { ...state, dagHistorySearch: action.search, dagHistoryPage: 0 };
-    case 'set-dag-history-unmigrated-only':
-      return { ...state, dagHistoryUnmigratedOnly: action.unmigratedOnly };
     case 'set-local-airflow-version':
       return { ...state, localAirflowVersion: action.version };
     case 'reset':
@@ -247,16 +244,8 @@ export function useDagHistoryConfig() {
       page: state.dagHistoryPage,
       pageSize: state.dagHistoryPageSize,
       search: state.dagHistorySearch,
-      unmigratedOnly: state.dagHistoryUnmigratedOnly,
     }),
-    [
-      state.limit,
-      state.batchSize,
-      state.dagHistoryPage,
-      state.dagHistoryPageSize,
-      state.dagHistorySearch,
-      state.dagHistoryUnmigratedOnly,
-    ],
+    [state.limit, state.batchSize, state.dagHistoryPage, state.dagHistoryPageSize, state.dagHistorySearch],
   );
 }
 

--- a/astronomer_starship/src/AppContext.jsx
+++ b/astronomer_starship/src/AppContext.jsx
@@ -40,6 +40,7 @@ const initialState = {
   dagHistoryPage: 0,
   dagHistoryPageSize: 50,
   dagHistorySearch: '',
+  dagHistorySearchField: 'any',
 
   // Local Airflow info
   localAirflowVersion: null,
@@ -121,6 +122,8 @@ function reducer(state, action) {
       return { ...state, dagHistoryPageSize: action.pageSize, dagHistoryPage: 0 };
     case 'set-dag-history-search':
       return { ...state, dagHistorySearch: action.search, dagHistoryPage: 0 };
+    case 'set-dag-history-search-field':
+      return { ...state, dagHistorySearchField: action.searchField, dagHistoryPage: 0 };
     case 'set-local-airflow-version':
       return { ...state, localAirflowVersion: action.version };
     case 'reset':
@@ -244,8 +247,16 @@ export function useDagHistoryConfig() {
       page: state.dagHistoryPage,
       pageSize: state.dagHistoryPageSize,
       search: state.dagHistorySearch,
+      searchField: state.dagHistorySearchField,
     }),
-    [state.limit, state.batchSize, state.dagHistoryPage, state.dagHistoryPageSize, state.dagHistorySearch],
+    [
+      state.limit,
+      state.batchSize,
+      state.dagHistoryPage,
+      state.dagHistoryPageSize,
+      state.dagHistorySearch,
+      state.dagHistorySearchField,
+    ],
   );
 }
 

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -25,6 +25,7 @@ import {
   NumberInput,
   NumberInputField,
   NumberInputStepper,
+  Progress,
   Select,
   Stack,
   Switch,
@@ -381,20 +382,34 @@ export default function DAGHistoryPage() {
   const { isOpen: isBulkPauseOpen, onOpen: openBulkPauseDialog, onClose: closeBulkPauseDialog } = useDisclosure();
   const [bulkPauseIntent, setBulkPauseIntent] = useState(null);
   const [isBulkPausing, setIsBulkPausing] = useState(false);
+  // Live progress shown inside the modal while the loop runs and after it finishes.
+  const [bulkPauseProgress, setBulkPauseProgress] = useState(null);
+  // Toggled by the Stop button to short-circuit the loop mid-run.
+  const bulkPauseAbortRef = useRef(false);
   const bulkPauseCancelRef = useRef(null);
 
   const requestBulkPause = useCallback(
     (isLocal, pause) => {
       setBulkPauseIntent({ isLocal, pause });
+      setBulkPauseProgress(null);
+      bulkPauseAbortRef.current = false;
       openBulkPauseDialog();
     },
     [openBulkPauseDialog],
   );
 
+  const dismissBulkPauseDialog = useCallback(() => {
+    bulkPauseAbortRef.current = true;
+    closeBulkPauseDialog();
+    setBulkPauseIntent(null);
+    setBulkPauseProgress(null);
+  }, [closeBulkPauseDialog]);
+
   const runBulkPause = useCallback(async () => {
     if (!bulkPauseIntent) return;
     const { isLocal, pause } = bulkPauseIntent;
     setIsBulkPausing(true);
+    bulkPauseAbortRef.current = false;
 
     try {
       const params = { limit: 99999, offset: 0 };
@@ -408,58 +423,52 @@ export default function DAGHistoryPage() {
       const targets = dags.filter((d) => d.is_paused !== pause);
 
       if (targets.length === 0) {
-        toast({
-          title: 'No changes needed',
-          description: `All matching ${isLocal ? 'local' : 'remote'} DAGs are already ${pause ? 'paused' : 'active'}`,
-          status: 'info',
-          duration: 4000,
-          variant: 'outline',
-        });
+        setBulkPauseProgress({ done: 0, failed: 0, total: 0, finished: true, aborted: false });
         return;
       }
 
-      toast({
-        title: `Updating ${targets.length} ${isLocal ? 'local' : 'remote'} DAGs...`,
-        status: 'info',
-        duration: 3000,
-        variant: 'outline',
-      });
+      setBulkPauseProgress({ done: 0, failed: 0, total: targets.length, finished: false, aborted: false });
 
-      let successCount = 0;
+      let done = 0;
+      let failed = 0;
       for (const dag of targets) {
+        if (bulkPauseAbortRef.current) break;
         try {
           await handlePausedClick(pause, dag.dag_id, isLocal);
-          successCount += 1;
+          done += 1;
         } catch (_err) {
-          // Continue on error
+          failed += 1;
         }
+        setBulkPauseProgress({
+          done,
+          failed,
+          total: targets.length,
+          finished: done + failed === targets.length,
+          aborted: false,
+        });
       }
 
-      const dagLabel = successCount !== 1 ? 'DAGs' : 'DAG';
-      const failedCount = targets.length - successCount;
-      toast({
-        title: `${pause ? 'Paused' : 'Activated'} ${successCount} ${isLocal ? 'local' : 'remote'} ${dagLabel}`,
-        description:
-          failedCount > 0
-            ? `${failedCount} ${failedCount !== 1 ? 'DAGs' : 'DAG'} failed to update`
-            : `Successfully updated ${isLocal ? 'local' : 'remote'} Airflow instance`,
-        status: failedCount > 0 ? 'warning' : 'success',
-        duration: 5000,
-        variant: 'outline',
+      const aborted = bulkPauseAbortRef.current;
+      setBulkPauseProgress({
+        done,
+        failed,
+        total: targets.length,
+        finished: true,
+        aborted,
       });
     } catch (err) {
-      toast({
-        title: 'Failed to fetch DAGs for bulk action',
-        description: err.message,
-        status: 'error',
-        duration: 5000,
-        variant: 'outline',
+      setBulkPauseProgress({
+        done: 0,
+        failed: 0,
+        total: 0,
+        finished: true,
+        aborted: false,
+        error: err.message,
       });
     } finally {
       setIsBulkPausing(false);
-      setBulkPauseIntent(null);
     }
-  }, [bulkPauseIntent, search, searchField, targetUrl, token, handlePausedClick, toast]);
+  }, [bulkPauseIntent, search, searchField, targetUrl, token, handlePausedClick]);
 
   const columns = useMemo(
     () =>
@@ -701,8 +710,10 @@ export default function DAGHistoryPage() {
       <AlertDialog
         isOpen={isBulkPauseOpen}
         leastDestructiveRef={bulkPauseCancelRef}
-        onClose={closeBulkPauseDialog}
+        onClose={dismissBulkPauseDialog}
         isCentered
+        closeOnEsc={!isBulkPausing}
+        closeOnOverlayClick={!isBulkPausing}
       >
         <AlertDialogOverlay>
           <AlertDialogContent>
@@ -710,33 +721,86 @@ export default function DAGHistoryPage() {
               {bulkPauseIntent?.pause ? 'Pause' : 'Unpause'} {bulkPauseIntent?.isLocal ? 'local' : 'remote'} DAGs
             </AlertDialogHeader>
             <AlertDialogBody>
-              This will {bulkPauseIntent?.pause ? 'pause' : 'unpause'} up to <strong>{totalCount}</strong>{' '}
-              {bulkPauseIntent?.isLocal ? 'local' : 'remote'} DAG
-              {totalCount === 1 ? '' : 's'}
-              {search ? (
+              {!bulkPauseProgress ? (
                 <>
-                  {' '}
-                  matching search <em>&quot;{search}&quot;</em>
-                  {searchField && searchField !== 'any' ? <> in {searchField.replace('_', ' ')}</> : null}
+                  This will {bulkPauseIntent?.pause ? 'pause' : 'unpause'} up to <strong>{totalCount}</strong>{' '}
+                  {bulkPauseIntent?.isLocal ? 'local' : 'remote'} DAG
+                  {totalCount === 1 ? '' : 's'}
+                  {search ? (
+                    <>
+                      {' '}
+                      matching search <em>&quot;{search}&quot;</em>
+                      {searchField && searchField !== 'any' ? <> in {searchField.replace('_', ' ')}</> : null}
+                    </>
+                  ) : null}
+                  . DAGs already in the desired state are skipped. Continue?
                 </>
-              ) : null}
-              . DAGs already in the desired state are skipped. Continue?
+              ) : bulkPauseProgress.error ? (
+                <Text color="red.600">Failed to fetch DAGs: {bulkPauseProgress.error}</Text>
+              ) : bulkPauseProgress.total === 0 ? (
+                <Text>
+                  All matching {bulkPauseIntent?.isLocal ? 'local' : 'remote'} DAGs are already{' '}
+                  {bulkPauseIntent?.pause ? 'paused' : 'active'}. Nothing to do.
+                </Text>
+              ) : (
+                <Box>
+                  <Text mb={2}>
+                    {bulkPauseProgress.finished
+                      ? bulkPauseProgress.aborted
+                        ? 'Stopped: '
+                        : 'Done: '
+                      : bulkPauseIntent?.pause
+                        ? 'Pausing '
+                        : 'Unpausing '}
+                    <strong>{bulkPauseProgress.done}</strong> of <strong>{bulkPauseProgress.total}</strong> DAGs
+                    {bulkPauseProgress.failed > 0 ? (
+                      <>
+                        {' '}
+                        (
+                        <Text as="span" color="red.600">
+                          {bulkPauseProgress.failed} failed
+                        </Text>
+                        )
+                      </>
+                    ) : null}
+                  </Text>
+                  <Progress
+                    value={((bulkPauseProgress.done + bulkPauseProgress.failed) * 100) / bulkPauseProgress.total}
+                    size="sm"
+                    colorScheme={bulkPauseIntent?.pause ? 'orange' : 'green'}
+                    hasStripe={!bulkPauseProgress.finished}
+                    isAnimated={!bulkPauseProgress.finished}
+                    borderRadius="md"
+                  />
+                </Box>
+              )}
             </AlertDialogBody>
             <AlertDialogFooter>
-              <Button ref={bulkPauseCancelRef} onClick={closeBulkPauseDialog} isDisabled={isBulkPausing}>
-                Cancel
-              </Button>
-              <Button
-                colorScheme={bulkPauseIntent?.pause ? 'orange' : 'green'}
-                onClick={() => {
-                  closeBulkPauseDialog();
-                  runBulkPause();
-                }}
-                isLoading={isBulkPausing}
-                ml={3}
-              >
-                {bulkPauseIntent?.pause ? 'Pause All' : 'Unpause All'}
-              </Button>
+              {!bulkPauseProgress ? (
+                <>
+                  <Button ref={bulkPauseCancelRef} onClick={dismissBulkPauseDialog}>
+                    Cancel
+                  </Button>
+                  <Button colorScheme={bulkPauseIntent?.pause ? 'orange' : 'green'} onClick={runBulkPause} ml={3}>
+                    {bulkPauseIntent?.pause ? 'Pause All' : 'Unpause All'}
+                  </Button>
+                </>
+              ) : !bulkPauseProgress.finished ? (
+                <Button
+                  ref={bulkPauseCancelRef}
+                  colorScheme="red"
+                  variant="outline"
+                  onClick={() => {
+                    bulkPauseAbortRef.current = true;
+                  }}
+                >
+                  Stop
+                </Button>
+              ) : (
+                <Button ref={bulkPauseCancelRef} onClick={dismissBulkPauseDialog}>
+                  Close
+                </Button>
+              )}
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialogOverlay>

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -825,10 +825,16 @@ export default function DAGHistoryPage() {
             <AlertDialogFooter>
               {!bulkPauseProgress ? (
                 <>
-                  <Button ref={bulkPauseCancelRef} onClick={dismissBulkPauseDialog}>
+                  <Button ref={bulkPauseCancelRef} onClick={dismissBulkPauseDialog} isDisabled={isBulkPausing}>
                     Cancel
                   </Button>
-                  <Button colorScheme={bulkPauseIntent?.pause ? 'orange' : 'green'} onClick={runBulkPause} ml={3}>
+                  <Button
+                    colorScheme={bulkPauseIntent?.pause ? 'orange' : 'green'}
+                    onClick={runBulkPause}
+                    ml={3}
+                    isLoading={isBulkPausing}
+                    loadingText="Loading DAGs..."
+                  >
                     {bulkPauseIntent?.pause ? 'Pause All' : 'Unpause All'}
                   </Button>
                 </>

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -329,16 +329,24 @@ export default function DAGHistoryPage() {
     return () => clearTimeout(t);
   }, [searchInput, search, dispatch]);
 
-  const handlePausedClick = useCallback(
+  const patchPauseState = useCallback(
     async (isPaused, dagId, isLocal) => {
       const url = isLocal ? localRoute(constants.DAGS_ROUTE) : proxyUrl(targetUrl + constants.DAGS_ROUTE);
+      const res = await axios.patch(url, { dag_id: dagId, is_paused: isPaused }, { headers: proxyHeaders(token) });
+      return res.data;
+    },
+    [targetUrl, token],
+  );
+
+  const handlePausedClick = useCallback(
+    async (isPaused, dagId, isLocal) => {
       try {
-        const res = await axios.patch(url, { dag_id: dagId, is_paused: isPaused }, { headers: proxyHeaders(token) });
+        const data = await patchPauseState(isPaused, dagId, isLocal);
         setData((prev) =>
           prev.map((item) => {
             if (item.local.dag_id !== dagId) return item;
             const key = isLocal ? 'local' : 'remote';
-            return { ...item, [key]: { ...item[key], is_paused: res.data.is_paused } };
+            return { ...item, [key]: { ...item[key], is_paused: data.is_paused } };
           }),
         );
       } catch (err) {
@@ -352,7 +360,7 @@ export default function DAGHistoryPage() {
         });
       }
     },
-    [targetUrl, token, toast],
+    [patchPauseState, toast],
   );
 
   const handleMigrate = useCallback((dagId, runCount) => {
@@ -412,7 +420,9 @@ export default function DAGHistoryPage() {
     bulkPauseAbortRef.current = false;
 
     try {
-      const params = { limit: 99999, offset: 0 };
+      // No `limit`/`offset`: the backend treats them as unset and returns every
+      // matching DAG, so we correctly hit deployments with more than ~99k DAGs.
+      const params = {};
       if (search) params.search = search;
       if (searchField && searchField !== 'any') params.search_field = searchField;
 
@@ -434,7 +444,7 @@ export default function DAGHistoryPage() {
       for (const dag of targets) {
         if (bulkPauseAbortRef.current) break;
         try {
-          await handlePausedClick(pause, dag.dag_id, isLocal);
+          await patchPauseState(pause, dag.dag_id, isLocal);
           done += 1;
         } catch (_err) {
           failed += 1;
@@ -447,6 +457,10 @@ export default function DAGHistoryPage() {
           aborted: false,
         });
       }
+
+      // Refresh visible-page data once at the end instead of poking setData per
+      // item; keeps the render cost O(1) for a 1000-item loop.
+      await fetchData();
 
       const aborted = bulkPauseAbortRef.current;
       setBulkPauseProgress({
@@ -468,7 +482,7 @@ export default function DAGHistoryPage() {
     } finally {
       setIsBulkPausing(false);
     }
-  }, [bulkPauseIntent, search, searchField, targetUrl, token, handlePausedClick]);
+  }, [bulkPauseIntent, search, searchField, targetUrl, token, patchPauseState, fetchData]);
 
   const columns = useMemo(
     () =>
@@ -733,9 +747,15 @@ export default function DAGHistoryPage() {
             <AlertDialogBody>
               {!bulkPauseProgress ? (
                 <>
-                  This will {bulkPauseIntent?.pause ? 'pause' : 'unpause'} up to <strong>{totalCount}</strong>{' '}
-                  {bulkPauseIntent?.isLocal ? 'local' : 'remote'} DAG
-                  {totalCount === 1 ? '' : 's'}
+                  This will {bulkPauseIntent?.pause ? 'pause' : 'unpause'}{' '}
+                  {bulkPauseIntent?.isLocal ? (
+                    <>
+                      up to <strong>{totalCount}</strong> local DAG
+                      {totalCount === 1 ? '' : 's'}
+                    </>
+                  ) : (
+                    <>all matching remote DAGs</>
+                  )}
                   {search ? (
                     <>
                       {' '}

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -4,7 +4,6 @@ import {
   Badge,
   Box,
   Button,
-  Checkbox,
   FormControl,
   Heading,
   HStack,
@@ -244,7 +243,7 @@ function createColumns(config) {
 
 export default function DAGHistoryPage() {
   const { targetUrl, token, localAirflowVersion } = useTargetConfig();
-  const { limit, batchSize, page, pageSize, search, unmigratedOnly } = useDagHistoryConfig();
+  const { limit, batchSize, page, pageSize, search } = useDagHistoryConfig();
   const dispatch = useAppDispatch();
   const toast = useToast();
 
@@ -252,9 +251,6 @@ export default function DAGHistoryPage() {
   const [error, setError] = useState(null);
   const [data, setData] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
-  // Set of dag_ids that exist on the target -- used by the "unmigrated only" filter.
-  // Fetched once per page mount; stays local (not in AppContext) since it can be sizeable.
-  const [targetDagIds, setTargetDagIds] = useState(() => new Set());
   // Local mirror of the search input so we can debounce dispatches to AppContext.
   const [searchInput, setSearchInput] = useState(search);
 
@@ -281,7 +277,7 @@ export default function DAGHistoryPage() {
 
       if (localRes.status === 200 && remoteRes.status === 200) {
         // Response shape (>=2.11): {dags: [...], total_dag_count: N}. Older releases returned a bare list.
-        const unwrap = (res) => (Array.isArray(res.data) ? res.data : res.data?.dags ?? []);
+        const unwrap = (res) => (Array.isArray(res.data) ? res.data : (res.data?.dags ?? []));
         const localDags = unwrap(localRes);
         const remoteDags = unwrap(remoteRes);
         setData(mergeDagData(localDags, remoteDags));
@@ -306,30 +302,6 @@ export default function DAGHistoryPage() {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
-
-  // One-time (per targetUrl change) fetch of every target dag_id so the "unmigrated only"
-  // filter can flag migrated rows accurately across pages. Payload is dag_ids-only-ish
-  // and typically <100KB even for thousands of DAGs.
-  useEffect(() => {
-    if (!targetUrl || !token) return undefined;
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await axios.get(proxyUrl(targetUrl + constants.DAGS_ROUTE), {
-          params: { limit: 10000, offset: 0 },
-          headers: proxyHeaders(token),
-        });
-        if (cancelled) return;
-        const dags = Array.isArray(res.data) ? res.data : res.data?.dags ?? [];
-        setTargetDagIds(new Set(dags.map((d) => d.dag_id)));
-      } catch {
-        // Non-fatal: the filter just becomes a no-op if we can't reach target here.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [targetUrl, token]);
 
   // Debounce search input -> AppContext dispatch (~300ms).
   useEffect(() => {
@@ -570,14 +542,6 @@ export default function DAGHistoryPage() {
             onChange={(e) => setSearchInput(e.target.value)}
           />
         </InputGroup>
-        <Checkbox
-          isChecked={unmigratedOnly}
-          onChange={(e) =>
-            dispatch({ type: 'set-dag-history-unmigrated-only', unmigratedOnly: e.target.checked })
-          }
-        >
-          Unmigrated only
-        </Checkbox>
         <Text fontSize="sm" color="gray.600" ml="auto">
           {totalCount === 0
             ? 'No DAGs'
@@ -590,11 +554,7 @@ export default function DAGHistoryPage() {
           {loading || error ? (
             <PageLoading loading={loading} error={error} />
           ) : (
-            <DataTable
-              data={unmigratedOnly ? data.filter((d) => !targetDagIds.has(d.local.dag_id)) : data}
-              columns={columns}
-              showSearch={false}
-            />
+            <DataTable data={data} columns={columns} showSearch={false} />
           )}
         </Box>
         {!loading && !error && totalCount > 0 && (
@@ -606,9 +566,7 @@ export default function DAGHistoryPage() {
               size="sm"
               w="20"
               value={pageSize}
-              onChange={(e) =>
-                dispatch({ type: 'set-dag-history-page-size', pageSize: Number(e.target.value) })
-              }
+              onChange={(e) => dispatch({ type: 'set-dag-history-page-size', pageSize: Number(e.target.value) })}
             >
               <option value={25}>25</option>
               <option value={50}>50</option>

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -1,6 +1,12 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { createColumnHelper } from '@tanstack/react-table';
 import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
   Badge,
   Box,
   Button,
@@ -24,6 +30,7 @@ import {
   Tag,
   Text,
   Tooltip,
+  useDisclosure,
   useToast,
   VStack,
 } from '@chakra-ui/react';
@@ -243,7 +250,7 @@ function createColumns(config) {
 
 export default function DAGHistoryPage() {
   const { targetUrl, token, localAirflowVersion } = useTargetConfig();
-  const { limit, batchSize, page, pageSize, search } = useDagHistoryConfig();
+  const { limit, batchSize, page, pageSize, search, searchField } = useDagHistoryConfig();
   const dispatch = useAppDispatch();
   const toast = useToast();
 
@@ -269,6 +276,7 @@ export default function DAGHistoryPage() {
 
       const params = { limit: pageSize, offset: page * pageSize };
       if (search) params.search = search;
+      if (searchField && searchField !== 'any') params.search_field = searchField;
 
       const [localRes, remoteRes] = await Promise.all([
         axios.get(localRoute(constants.DAGS_ROUTE), { params }),
@@ -297,7 +305,7 @@ export default function DAGHistoryPage() {
     } finally {
       setLoading(false);
     }
-  }, [targetUrl, token, dispatch, localAirflowVersion, page, pageSize, search]);
+  }, [targetUrl, token, dispatch, localAirflowVersion, page, pageSize, search, searchField]);
 
   useEffect(() => {
     fetchData();
@@ -360,17 +368,41 @@ export default function DAGHistoryPage() {
     );
   }, []);
 
-  const handleBulkPause = useCallback(
-    async (isLocal, pause) => {
-      const items = data.filter((item) => {
-        const target = isLocal ? item.local : item.remote;
-        return target && target.is_paused !== pause;
-      });
+  // Bulk pause/unpause: opens a confirmation modal, then fetches ALL matching
+  // DAGs (across pages) and updates them. Respects the current search filter.
+  const { isOpen: isBulkPauseOpen, onOpen: openBulkPauseDialog, onClose: closeBulkPauseDialog } = useDisclosure();
+  const [bulkPauseIntent, setBulkPauseIntent] = useState(null);
+  const [isBulkPausing, setIsBulkPausing] = useState(false);
+  const bulkPauseCancelRef = useRef(null);
 
-      if (items.length === 0) {
+  const requestBulkPause = useCallback(
+    (isLocal, pause) => {
+      setBulkPauseIntent({ isLocal, pause });
+      openBulkPauseDialog();
+    },
+    [openBulkPauseDialog],
+  );
+
+  const runBulkPause = useCallback(async () => {
+    if (!bulkPauseIntent) return;
+    const { isLocal, pause } = bulkPauseIntent;
+    setIsBulkPausing(true);
+
+    try {
+      const params = { limit: 99999, offset: 0 };
+      if (search) params.search = search;
+      if (searchField && searchField !== 'any') params.search_field = searchField;
+
+      const url = isLocal ? localRoute(constants.DAGS_ROUTE) : proxyUrl(targetUrl + constants.DAGS_ROUTE);
+      const cfg = isLocal ? { params } : { params, headers: proxyHeaders(token) };
+      const res = await axios.get(url, cfg);
+      const dags = Array.isArray(res.data) ? res.data : (res.data?.dags ?? []);
+      const targets = dags.filter((d) => d.is_paused !== pause);
+
+      if (targets.length === 0) {
         toast({
           title: 'No changes needed',
-          description: `All ${isLocal ? 'local' : 'remote'} DAGs are already ${pause ? 'paused' : 'active'}`,
+          description: `All matching ${isLocal ? 'local' : 'remote'} DAGs are already ${pause ? 'paused' : 'active'}`,
           status: 'info',
           duration: 4000,
           variant: 'outline',
@@ -378,11 +410,17 @@ export default function DAGHistoryPage() {
         return;
       }
 
-      let successCount = 0;
+      toast({
+        title: `Updating ${targets.length} ${isLocal ? 'local' : 'remote'} DAGs...`,
+        status: 'info',
+        duration: 3000,
+        variant: 'outline',
+      });
 
-      for (const item of items) {
+      let successCount = 0;
+      for (const dag of targets) {
         try {
-          await handlePausedClick(pause, item.local.dag_id, isLocal);
+          await handlePausedClick(pause, dag.dag_id, isLocal);
           successCount += 1;
         } catch (_err) {
           // Continue on error
@@ -390,21 +428,30 @@ export default function DAGHistoryPage() {
       }
 
       const dagLabel = successCount !== 1 ? 'DAGs' : 'DAG';
-      const locationLabel = isLocal ? 'local' : 'remote';
-      const failedCount = items.length - successCount;
+      const failedCount = targets.length - successCount;
       toast({
-        title: `${pause ? 'Paused' : 'Activated'} ${successCount} ${locationLabel} ${dagLabel}`,
+        title: `${pause ? 'Paused' : 'Activated'} ${successCount} ${isLocal ? 'local' : 'remote'} ${dagLabel}`,
         description:
           failedCount > 0
             ? `${failedCount} ${failedCount !== 1 ? 'DAGs' : 'DAG'} failed to update`
-            : `Successfully updated ${locationLabel} Airflow instance`,
+            : `Successfully updated ${isLocal ? 'local' : 'remote'} Airflow instance`,
         status: failedCount > 0 ? 'warning' : 'success',
-        duration: 4000,
+        duration: 5000,
         variant: 'outline',
       });
-    },
-    [data, toast, handlePausedClick],
-  );
+    } catch (err) {
+      toast({
+        title: 'Failed to fetch DAGs for bulk action',
+        description: err.message,
+        status: 'error',
+        duration: 5000,
+        variant: 'outline',
+      });
+    } finally {
+      setIsBulkPausing(false);
+      setBulkPauseIntent(null);
+    }
+  }, [bulkPauseIntent, search, searchField, targetUrl, token, handlePausedClick, toast]);
 
   const columns = useMemo(
     () =>
@@ -490,7 +537,7 @@ export default function DAGHistoryPage() {
           <Button
             size="sm"
             leftIcon={<FiPause />}
-            onClick={() => handleBulkPause(true, true)}
+            onClick={() => requestBulkPause(true, true)}
             colorScheme="orange"
             variant="outline"
           >
@@ -499,7 +546,7 @@ export default function DAGHistoryPage() {
           <Button
             size="sm"
             leftIcon={<FiPlay />}
-            onClick={() => handleBulkPause(true, false)}
+            onClick={() => requestBulkPause(true, false)}
             colorScheme="green"
             variant="outline"
           >
@@ -513,7 +560,7 @@ export default function DAGHistoryPage() {
           <Button
             size="sm"
             leftIcon={<FiPause />}
-            onClick={() => handleBulkPause(false, true)}
+            onClick={() => requestBulkPause(false, true)}
             colorScheme="orange"
             variant="outline"
           >
@@ -522,7 +569,7 @@ export default function DAGHistoryPage() {
           <Button
             size="sm"
             leftIcon={<FiPlay />}
-            onClick={() => handleBulkPause(false, false)}
+            onClick={() => requestBulkPause(false, false)}
             colorScheme="green"
             variant="outline"
           >
@@ -532,12 +579,31 @@ export default function DAGHistoryPage() {
       </HStack>
 
       <HStack spacing={3} mb={3} align="center">
+        <Select
+          size="sm"
+          w="32"
+          value={searchField}
+          onChange={(e) => dispatch({ type: 'set-dag-history-search-field', searchField: e.target.value })}
+        >
+          <option value="any">Any field</option>
+          <option value="dag_id">DAG ID</option>
+          <option value="owner">Owner</option>
+          <option value="tag">Tag</option>
+        </Select>
         <InputGroup size="sm" maxW="sm">
           <InputLeftElement pointerEvents="none">
             <SearchIcon color="gray.400" />
           </InputLeftElement>
           <Input
-            placeholder="Search DAGs by ID, tag, owner..."
+            placeholder={
+              searchField === 'dag_id'
+                ? 'Search by DAG ID...'
+                : searchField === 'owner'
+                  ? 'Search by owner...'
+                  : searchField === 'tag'
+                    ? 'Search by tag...'
+                    : 'Search by ID, tag, or owner...'
+            }
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
           />
@@ -593,6 +659,50 @@ export default function DAGHistoryPage() {
           </HStack>
         )}
       </VStack>
+
+      <AlertDialog
+        isOpen={isBulkPauseOpen}
+        leastDestructiveRef={bulkPauseCancelRef}
+        onClose={closeBulkPauseDialog}
+        isCentered
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              {bulkPauseIntent?.pause ? 'Pause' : 'Unpause'} {bulkPauseIntent?.isLocal ? 'local' : 'remote'} DAGs
+            </AlertDialogHeader>
+            <AlertDialogBody>
+              This will {bulkPauseIntent?.pause ? 'pause' : 'unpause'} up to <strong>{totalCount}</strong>{' '}
+              {bulkPauseIntent?.isLocal ? 'local' : 'remote'} DAG
+              {totalCount === 1 ? '' : 's'}
+              {search ? (
+                <>
+                  {' '}
+                  matching search <em>&quot;{search}&quot;</em>
+                  {searchField && searchField !== 'any' ? <> in {searchField.replace('_', ' ')}</> : null}
+                </>
+              ) : null}
+              . DAGs already in the desired state are skipped. Continue?
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <Button ref={bulkPauseCancelRef} onClick={closeBulkPauseDialog} isDisabled={isBulkPausing}>
+                Cancel
+              </Button>
+              <Button
+                colorScheme={bulkPauseIntent?.pause ? 'orange' : 'green'}
+                onClick={() => {
+                  closeBulkPauseDialog();
+                  runBulkPause();
+                }}
+                isLoading={isBulkPausing}
+                ml={3}
+              >
+                {bulkPauseIntent?.pause ? 'Pause All' : 'Unpause All'}
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
     </Box>
   );
 }

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -601,22 +601,15 @@ export default function DAGHistoryPage() {
             px={3}
             h="8"
             bg="gray.50"
-            spacing={1.5}
+            spacing={2}
             borderRight="1px solid"
             borderColor="gray.200"
             alignItems="center"
             flexShrink={0}
             lineHeight="1"
           >
-            <Icon as={FiFilter} boxSize={3.5} color="gray.500" display="block" />
-            <Text
-              fontSize="xs"
-              fontWeight="semibold"
-              color="gray.600"
-              textTransform="uppercase"
-              letterSpacing="wider"
-              lineHeight="1"
-            >
+            <Icon as={FiFilter} boxSize={4} color="gray.500" display="block" />
+            <Text fontSize="sm" fontWeight="medium" color="gray.700" lineHeight="1">
               Filter
             </Text>
           </HStack>

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -597,9 +597,26 @@ export default function DAGHistoryPage() {
 
       <HStack spacing={3} mb={3} align="center">
         <HStack spacing={0} border="1px solid" borderColor="gray.200" borderRadius="md" overflow="hidden" bg="white">
-          <HStack px={3} h="8" bg="gray.50" spacing={1.5} borderRight="1px solid" borderColor="gray.200">
-            <Icon as={FiFilter} boxSize={3.5} color="gray.500" />
-            <Text fontSize="xs" fontWeight="semibold" color="gray.600" textTransform="uppercase" letterSpacing="wider">
+          <HStack
+            px={3}
+            h="8"
+            bg="gray.50"
+            spacing={1.5}
+            borderRight="1px solid"
+            borderColor="gray.200"
+            alignItems="center"
+            flexShrink={0}
+            lineHeight="1"
+          >
+            <Icon as={FiFilter} boxSize={3.5} color="gray.500" display="block" />
+            <Text
+              fontSize="xs"
+              fontWeight="semibold"
+              color="gray.600"
+              textTransform="uppercase"
+              letterSpacing="wider"
+              lineHeight="1"
+            >
               Filter
             </Text>
           </HStack>

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -13,6 +13,7 @@ import {
   FormControl,
   Heading,
   HStack,
+  Icon,
   IconButton,
   Input,
   InputGroup,
@@ -36,8 +37,15 @@ import {
 } from '@chakra-ui/react';
 import axios from 'axios';
 import humanFormat from 'human-format';
-import { ChevronLeftIcon, ChevronRightIcon, ExternalLinkIcon, RepeatIcon, SearchIcon } from '@chakra-ui/icons';
-import { FiPause, FiPlay } from 'react-icons/fi';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CloseIcon,
+  ExternalLinkIcon,
+  RepeatIcon,
+  SearchIcon,
+} from '@chakra-ui/icons';
+import { FiFilter, FiPause, FiPlay } from 'react-icons/fi';
 import { useAppDispatch, useTargetConfig, useDagHistoryConfig } from '../AppContext';
 import DataTable from '../component/DataTable';
 import PageLoading from '../component/PageLoading';
@@ -579,35 +587,65 @@ export default function DAGHistoryPage() {
       </HStack>
 
       <HStack spacing={3} mb={3} align="center">
-        <Select
-          size="sm"
-          w="32"
-          value={searchField}
-          onChange={(e) => dispatch({ type: 'set-dag-history-search-field', searchField: e.target.value })}
-        >
-          <option value="any">Any field</option>
-          <option value="dag_id">DAG ID</option>
-          <option value="owner">Owner</option>
-          <option value="tag">Tag</option>
-        </Select>
-        <InputGroup size="sm" maxW="sm">
-          <InputLeftElement pointerEvents="none">
-            <SearchIcon color="gray.400" />
-          </InputLeftElement>
-          <Input
-            placeholder={
-              searchField === 'dag_id'
-                ? 'Search by DAG ID...'
-                : searchField === 'owner'
-                  ? 'Search by owner...'
-                  : searchField === 'tag'
-                    ? 'Search by tag...'
-                    : 'Search by ID, tag, or owner...'
-            }
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-          />
-        </InputGroup>
+        <HStack spacing={0} border="1px solid" borderColor="gray.200" borderRadius="md" overflow="hidden" bg="white">
+          <HStack px={3} h="8" bg="gray.50" spacing={1.5} borderRight="1px solid" borderColor="gray.200">
+            <Icon as={FiFilter} boxSize={3.5} color="gray.500" />
+            <Text fontSize="xs" fontWeight="semibold" color="gray.600" textTransform="uppercase" letterSpacing="wider">
+              Filter
+            </Text>
+          </HStack>
+          <Select
+            size="sm"
+            w="32"
+            value={searchField}
+            onChange={(e) => dispatch({ type: 'set-dag-history-search-field', searchField: e.target.value })}
+            border="0"
+            borderRadius={0}
+            _focus={{ boxShadow: 'none' }}
+            aria-label="Filter field"
+          >
+            <option value="any">Any field</option>
+            <option value="dag_id">DAG ID</option>
+            <option value="owner">Owner</option>
+            <option value="tag">Tag</option>
+          </Select>
+          <InputGroup size="sm" w="64" borderLeft="1px solid" borderColor="gray.200">
+            <InputLeftElement pointerEvents="none">
+              <SearchIcon color="gray.400" boxSize={3.5} />
+            </InputLeftElement>
+            <Input
+              border="0"
+              borderRadius={0}
+              placeholder={
+                searchField === 'dag_id'
+                  ? 'Search by DAG ID...'
+                  : searchField === 'owner'
+                    ? 'Search by owner...'
+                    : searchField === 'tag'
+                      ? 'Search by tag...'
+                      : 'Search by ID, tag, or owner...'
+              }
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              _focus={{ boxShadow: 'none' }}
+              aria-label="Filter value"
+            />
+          </InputGroup>
+        </HStack>
+        {(searchInput || (searchField && searchField !== 'any')) && (
+          <Button
+            size="sm"
+            variant="ghost"
+            leftIcon={<CloseIcon boxSize={2.5} />}
+            onClick={() => {
+              setSearchInput('');
+              dispatch({ type: 'set-dag-history-search', search: '' });
+              dispatch({ type: 'set-dag-history-search-field', searchField: 'any' });
+            }}
+          >
+            Reset
+          </Button>
+        )}
         <Text fontSize="sm" color="gray.600" ml="auto">
           {totalCount === 0
             ? 'No DAGs'

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -4,17 +4,22 @@ import {
   Badge,
   Box,
   Button,
+  Checkbox,
   FormControl,
   Heading,
   HStack,
+  IconButton,
+  Input,
   InputGroup,
   InputLeftAddon,
+  InputLeftElement,
   Link,
   NumberDecrementStepper,
   NumberIncrementStepper,
   NumberInput,
   NumberInputField,
   NumberInputStepper,
+  Select,
   Stack,
   Switch,
   Tag,
@@ -25,7 +30,7 @@ import {
 } from '@chakra-ui/react';
 import axios from 'axios';
 import humanFormat from 'human-format';
-import { ExternalLinkIcon, RepeatIcon } from '@chakra-ui/icons';
+import { ChevronLeftIcon, ChevronRightIcon, ExternalLinkIcon, RepeatIcon, SearchIcon } from '@chakra-ui/icons';
 import { FiPause, FiPlay } from 'react-icons/fi';
 import { useAppDispatch, useTargetConfig, useDagHistoryConfig } from '../AppContext';
 import DataTable from '../component/DataTable';
@@ -239,13 +244,19 @@ function createColumns(config) {
 
 export default function DAGHistoryPage() {
   const { targetUrl, token, localAirflowVersion } = useTargetConfig();
-  const { limit, batchSize } = useDagHistoryConfig();
+  const { limit, batchSize, page, pageSize, search, unmigratedOnly } = useDagHistoryConfig();
   const dispatch = useAppDispatch();
   const toast = useToast();
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [data, setData] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
+  // Set of dag_ids that exist on the target -- used by the "unmigrated only" filter.
+  // Fetched once per page mount; stays local (not in AppContext) since it can be sizeable.
+  const [targetDagIds, setTargetDagIds] = useState(() => new Set());
+  // Local mirror of the search input so we can debounce dispatches to AppContext.
+  const [searchInput, setSearchInput] = useState(search);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -260,13 +271,25 @@ export default function DAGHistoryPage() {
         }
       }
 
+      const params = { limit: pageSize, offset: page * pageSize };
+      if (search) params.search = search;
+
       const [localRes, remoteRes] = await Promise.all([
-        axios.get(localRoute(constants.DAGS_ROUTE)),
-        axios.get(proxyUrl(targetUrl + constants.DAGS_ROUTE), { headers: proxyHeaders(token) }),
+        axios.get(localRoute(constants.DAGS_ROUTE), { params }),
+        axios.get(proxyUrl(targetUrl + constants.DAGS_ROUTE), { params, headers: proxyHeaders(token) }),
       ]);
 
       if (localRes.status === 200 && remoteRes.status === 200) {
-        setData(mergeDagData(localRes.data, remoteRes.data));
+        // Response shape (>=2.11): {dags: [...], total_dag_count: N}. Older releases returned a bare list.
+        const unwrap = (res) => (Array.isArray(res.data) ? res.data : res.data?.dags ?? []);
+        const localDags = unwrap(localRes);
+        const remoteDags = unwrap(remoteRes);
+        setData(mergeDagData(localDags, remoteDags));
+        // Total from the source is authoritative for pagination; target count may differ.
+        const nextTotal = Array.isArray(localRes.data)
+          ? localDags.length
+          : (localRes.data?.total_dag_count ?? localDags.length);
+        setTotalCount(nextTotal);
       } else {
         throw new Error('Invalid response from server');
       }
@@ -278,11 +301,44 @@ export default function DAGHistoryPage() {
     } finally {
       setLoading(false);
     }
-  }, [targetUrl, token, dispatch, localAirflowVersion]);
+  }, [targetUrl, token, dispatch, localAirflowVersion, page, pageSize, search]);
 
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // One-time (per targetUrl change) fetch of every target dag_id so the "unmigrated only"
+  // filter can flag migrated rows accurately across pages. Payload is dag_ids-only-ish
+  // and typically <100KB even for thousands of DAGs.
+  useEffect(() => {
+    if (!targetUrl || !token) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await axios.get(proxyUrl(targetUrl + constants.DAGS_ROUTE), {
+          params: { limit: 10000, offset: 0 },
+          headers: proxyHeaders(token),
+        });
+        if (cancelled) return;
+        const dags = Array.isArray(res.data) ? res.data : res.data?.dags ?? [];
+        setTargetDagIds(new Set(dags.map((d) => d.dag_id)));
+      } catch {
+        // Non-fatal: the filter just becomes a no-op if we can't reach target here.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [targetUrl, token]);
+
+  // Debounce search input -> AppContext dispatch (~300ms).
+  useEffect(() => {
+    if (searchInput === search) return undefined;
+    const t = setTimeout(() => {
+      dispatch({ type: 'set-dag-history-search', search: searchInput });
+    }, 300);
+    return () => clearTimeout(t);
+  }, [searchInput, search, dispatch]);
 
   const handlePausedClick = useCallback(
     async (isPaused, dagId, isLocal) => {
@@ -503,14 +559,81 @@ export default function DAGHistoryPage() {
         </HStack>
       </HStack>
 
+      <HStack spacing={3} mb={3} align="center">
+        <InputGroup size="sm" maxW="sm">
+          <InputLeftElement pointerEvents="none">
+            <SearchIcon color="gray.400" />
+          </InputLeftElement>
+          <Input
+            placeholder="Search DAGs by ID, tag, owner..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+          />
+        </InputGroup>
+        <Checkbox
+          isChecked={unmigratedOnly}
+          onChange={(e) =>
+            dispatch({ type: 'set-dag-history-unmigrated-only', unmigratedOnly: e.target.checked })
+          }
+        >
+          Unmigrated only
+        </Checkbox>
+        <Text fontSize="sm" color="gray.600" ml="auto">
+          {totalCount === 0
+            ? 'No DAGs'
+            : `Showing ${page * pageSize + 1}\u2013${Math.min((page + 1) * pageSize, totalCount)} of ${totalCount}`}
+        </Text>
+      </HStack>
+
       <VStack spacing={3} align="stretch" w="100%">
         <Box>
           {loading || error ? (
             <PageLoading loading={loading} error={error} />
           ) : (
-            <DataTable data={data} columns={columns} searchPlaceholder="Search DAGs by ID, tags, owners..." />
+            <DataTable
+              data={unmigratedOnly ? data.filter((d) => !targetDagIds.has(d.local.dag_id)) : data}
+              columns={columns}
+              showSearch={false}
+            />
           )}
         </Box>
+        {!loading && !error && totalCount > 0 && (
+          <HStack spacing={2} justify="flex-end" align="center">
+            <Text fontSize="sm" color="gray.600">
+              Rows per page:
+            </Text>
+            <Select
+              size="sm"
+              w="20"
+              value={pageSize}
+              onChange={(e) =>
+                dispatch({ type: 'set-dag-history-page-size', pageSize: Number(e.target.value) })
+              }
+            >
+              <option value={25}>25</option>
+              <option value={50}>50</option>
+              <option value={100}>100</option>
+              <option value={200}>200</option>
+            </Select>
+            <IconButton
+              size="sm"
+              aria-label="Previous page"
+              icon={<ChevronLeftIcon />}
+              onClick={() => dispatch({ type: 'set-dag-history-page', page: Math.max(0, page - 1) })}
+              isDisabled={page === 0}
+            />
+            <Text fontSize="sm" color="gray.600" minW="20" textAlign="center">
+              Page {page + 1} of {Math.max(1, Math.ceil(totalCount / pageSize))}
+            </Text>
+            <IconButton
+              size="sm"
+              aria-label="Next page"
+              icon={<ChevronRightIcon />}
+              onClick={() => dispatch({ type: 'set-dag-history-page', page: page + 1 })}
+              isDisabled={(page + 1) * pageSize >= totalCount}
+            />
+          </HStack>
+        )}
       </VStack>
     </Box>
   );

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -320,6 +320,20 @@ export default function DAGHistoryPage() {
     fetchData();
   }, [fetchData]);
 
+  // Keep local input mirror in sync when `search` changes externally
+  // (e.g. token invalidation resetting AppContext).
+  useEffect(() => {
+    setSearchInput(search);
+  }, [search]);
+
+  // A saved page can point past totalCount (deployment shrank, filter narrowed,
+  // or state was persisted from a larger deployment). Snap back to page 0.
+  useEffect(() => {
+    if (totalCount > 0 && page * pageSize >= totalCount) {
+      dispatch({ type: 'set-dag-history-page', page: 0 });
+    }
+  }, [totalCount, page, pageSize, dispatch]);
+
   // Debounce search input -> AppContext dispatch (~300ms).
   useEffect(() => {
     if (searchInput === search) return undefined;
@@ -440,6 +454,9 @@ export default function DAGHistoryPage() {
 
       let done = 0;
       let failed = 0;
+      // Batch state updates so a 1000-item loop doesn't cause 1000 re-renders;
+      // always emit the final state so the modal shows the exact totals.
+      const shouldEmit = (processed) => processed === targets.length || targets.length <= 50 || processed % 10 === 0;
       for (const dag of targets) {
         if (bulkPauseAbortRef.current) break;
         try {
@@ -448,13 +465,16 @@ export default function DAGHistoryPage() {
         } catch (_err) {
           failed += 1;
         }
-        setBulkPauseProgress({
-          done,
-          failed,
-          total: targets.length,
-          finished: done + failed === targets.length,
-          aborted: false,
-        });
+        const processed = done + failed;
+        if (shouldEmit(processed)) {
+          setBulkPauseProgress({
+            done,
+            failed,
+            total: targets.length,
+            finished: processed === targets.length,
+            aborted: false,
+          });
+        }
       }
 
       await fetchData();

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -332,7 +332,8 @@ export default function DAGHistoryPage() {
   const patchPauseState = useCallback(
     async (isPaused, dagId, isLocal) => {
       const url = isLocal ? localRoute(constants.DAGS_ROUTE) : proxyUrl(targetUrl + constants.DAGS_ROUTE);
-      const res = await axios.patch(url, { dag_id: dagId, is_paused: isPaused }, { headers: proxyHeaders(token) });
+      const cfg = isLocal ? {} : { headers: proxyHeaders(token) };
+      const res = await axios.patch(url, { dag_id: dagId, is_paused: isPaused }, cfg);
       return res.data;
     },
     [targetUrl, token],

--- a/astronomer_starship/src/pages/DAGHistoryPage.jsx
+++ b/astronomer_starship/src/pages/DAGHistoryPage.jsx
@@ -420,8 +420,6 @@ export default function DAGHistoryPage() {
     bulkPauseAbortRef.current = false;
 
     try {
-      // No `limit`/`offset`: the backend treats them as unset and returns every
-      // matching DAG, so we correctly hit deployments with more than ~99k DAGs.
       const params = {};
       if (search) params.search = search;
       if (searchField && searchField !== 'any') params.search_field = searchField;
@@ -458,8 +456,6 @@ export default function DAGHistoryPage() {
         });
       }
 
-      // Refresh visible-page data once at the end instead of poking setData per
-      // item; keeps the render cost O(1) for a 1000-item loop.
       await fetchData();
 
       const aborted = bulkPauseAbortRef.current;

--- a/astronomer_starship/tests/src/AppContext.test.jsx
+++ b/astronomer_starship/tests/src/AppContext.test.jsx
@@ -12,11 +12,12 @@ describe('AppContext DAG History pagination reducer', () => {
     localStorage.clear();
   });
 
-  test('defaults expose page=0, pageSize=50, empty search', () => {
+  test('defaults expose page=0, pageSize=50, empty search, searchField=any', () => {
     const { result } = renderHook(() => useDagHistoryConfig(), { wrapper });
     expect(result.current.page).toBe(0);
     expect(result.current.pageSize).toBe(50);
     expect(result.current.search).toBe('');
+    expect(result.current.searchField).toBe('any');
   });
 
   test('set-dag-history-page updates page only', () => {
@@ -39,6 +40,14 @@ describe('AppContext DAG History pagination reducer', () => {
     act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 4 }));
     act(() => result.current.dispatch({ type: 'set-dag-history-search', search: 'example' }));
     expect(result.current.config.search).toBe('example');
+    expect(result.current.config.page).toBe(0);
+  });
+
+  test('set-dag-history-search-field resets page and stores field', () => {
+    const { result } = renderHook(() => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }), { wrapper });
+    act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 3 }));
+    act(() => result.current.dispatch({ type: 'set-dag-history-search-field', searchField: 'tag' }));
+    expect(result.current.config.searchField).toBe('tag');
     expect(result.current.config.page).toBe(0);
   });
 });

--- a/astronomer_starship/tests/src/AppContext.test.jsx
+++ b/astronomer_starship/tests/src/AppContext.test.jsx
@@ -12,29 +12,22 @@ describe('AppContext DAG History pagination reducer', () => {
     localStorage.clear();
   });
 
-  test('defaults expose page=0, pageSize=50, empty search, filter off', () => {
+  test('defaults expose page=0, pageSize=50, empty search', () => {
     const { result } = renderHook(() => useDagHistoryConfig(), { wrapper });
     expect(result.current.page).toBe(0);
     expect(result.current.pageSize).toBe(50);
     expect(result.current.search).toBe('');
-    expect(result.current.unmigratedOnly).toBe(false);
   });
 
   test('set-dag-history-page updates page only', () => {
-    const { result } = renderHook(
-      () => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }),
-      { wrapper },
-    );
+    const { result } = renderHook(() => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }), { wrapper });
     act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 3 }));
     expect(result.current.config.page).toBe(3);
     expect(result.current.config.pageSize).toBe(50);
   });
 
   test('set-dag-history-page-size resets page to 0 so stale offsets do not overshoot', () => {
-    const { result } = renderHook(
-      () => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }),
-      { wrapper },
-    );
+    const { result } = renderHook(() => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }), { wrapper });
     act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 5 }));
     act(() => result.current.dispatch({ type: 'set-dag-history-page-size', pageSize: 25 }));
     expect(result.current.config.pageSize).toBe(25);
@@ -42,24 +35,10 @@ describe('AppContext DAG History pagination reducer', () => {
   });
 
   test('set-dag-history-search resets page and stores query', () => {
-    const { result } = renderHook(
-      () => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }),
-      { wrapper },
-    );
+    const { result } = renderHook(() => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }), { wrapper });
     act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 4 }));
     act(() => result.current.dispatch({ type: 'set-dag-history-search', search: 'example' }));
     expect(result.current.config.search).toBe('example');
     expect(result.current.config.page).toBe(0);
-  });
-
-  test('set-dag-history-unmigrated-only toggles without touching pagination', () => {
-    const { result } = renderHook(
-      () => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }),
-      { wrapper },
-    );
-    act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 2 }));
-    act(() => result.current.dispatch({ type: 'set-dag-history-unmigrated-only', unmigratedOnly: true }));
-    expect(result.current.config.unmigratedOnly).toBe(true);
-    expect(result.current.config.page).toBe(2);
   });
 });

--- a/astronomer_starship/tests/src/AppContext.test.jsx
+++ b/astronomer_starship/tests/src/AppContext.test.jsx
@@ -1,0 +1,65 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { AppProvider, useAppDispatch, useDagHistoryConfig } from '../../src/AppContext';
+
+function wrapper({ children }) {
+  return <AppProvider>{children}</AppProvider>;
+}
+
+describe('AppContext DAG History pagination reducer', () => {
+  beforeEach(() => {
+    // Ensure each test starts from a clean localStorage-backed initial state.
+    localStorage.clear();
+  });
+
+  test('defaults expose page=0, pageSize=50, empty search, filter off', () => {
+    const { result } = renderHook(() => useDagHistoryConfig(), { wrapper });
+    expect(result.current.page).toBe(0);
+    expect(result.current.pageSize).toBe(50);
+    expect(result.current.search).toBe('');
+    expect(result.current.unmigratedOnly).toBe(false);
+  });
+
+  test('set-dag-history-page updates page only', () => {
+    const { result } = renderHook(
+      () => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }),
+      { wrapper },
+    );
+    act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 3 }));
+    expect(result.current.config.page).toBe(3);
+    expect(result.current.config.pageSize).toBe(50);
+  });
+
+  test('set-dag-history-page-size resets page to 0 so stale offsets do not overshoot', () => {
+    const { result } = renderHook(
+      () => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }),
+      { wrapper },
+    );
+    act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 5 }));
+    act(() => result.current.dispatch({ type: 'set-dag-history-page-size', pageSize: 25 }));
+    expect(result.current.config.pageSize).toBe(25);
+    expect(result.current.config.page).toBe(0);
+  });
+
+  test('set-dag-history-search resets page and stores query', () => {
+    const { result } = renderHook(
+      () => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }),
+      { wrapper },
+    );
+    act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 4 }));
+    act(() => result.current.dispatch({ type: 'set-dag-history-search', search: 'example' }));
+    expect(result.current.config.search).toBe('example');
+    expect(result.current.config.page).toBe(0);
+  });
+
+  test('set-dag-history-unmigrated-only toggles without touching pagination', () => {
+    const { result } = renderHook(
+      () => ({ config: useDagHistoryConfig(), dispatch: useAppDispatch() }),
+      { wrapper },
+    );
+    act(() => result.current.dispatch({ type: 'set-dag-history-page', page: 2 }));
+    act(() => result.current.dispatch({ type: 'set-dag-history-unmigrated-only', unmigratedOnly: true }));
+    expect(result.current.config.unmigratedOnly).toBe(true);
+    expect(result.current.config.page).toBe(2);
+  });
+});

--- a/docs/api.md
+++ b/docs/api.md
@@ -266,25 +266,37 @@ Get DAG or pause/unpause a DAG
 
 ### `GET /api/starship/dags`
 
-**Parameters:** None
+**Parameters:** Args
+
+| Field (*=Required) | Version | Type | Example |
+|--------------------|---------|------|---------|
+| limit              | >=2.11  | int  | 50      |
+| offset             | >=2.11  | int  | 0       |
+| search             | >=2.11  | str  | example |
+
+When `limit`/`offset` are omitted, all DAGs are returned. `search` matches (case-insensitive substring) against `dag_id`, `owners`, and any DAG tag.
 
 **Response**:
 
 ```json
-[
-    {
-        "dag_id": "dag_0",
-        "schedule_interval": "0 0 * * *",
-        "is_paused": true,
-        "fileloc": "/usr/local/airflow/dags/dag_0.py",
-        "description": "My Dag",
-        "owners": "user",
-        "tags": ["tag1", "tag2"],
-        "dag_run_count": 2,
-    },
-    ...
-]
+{
+    "dags": [
+        {
+            "dag_id": "dag_0",
+            "schedule_interval": "0 0 * * *",
+            "is_paused": true,
+            "fileloc": "/usr/local/airflow/dags/dag_0.py",
+            "description": "My Dag",
+            "owners": "user",
+            "tags": ["tag1", "tag2"],
+            "dag_run_count": 2
+        }
+    ],
+    "total_dag_count": 1
+}
 ```
+
+`total_dag_count` reflects the total number of DAGs matching `search` (or the full set when no `search` is given), independent of `limit`/`offset`. Rows are ordered by `dag_id` for stable pagination.
 
 ### `PATCH /api/starship/dags`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -281,6 +281,10 @@ default. Set `search_field` to `dag_id`, `owner`, or `tag` to restrict the
 match to that single column; any other value (or unset) preserves the default
 "any of the three" behaviour.
 
+The schedule field on each row is `schedule_interval` on Airflow 2.x and
+`timetable_summary` on Airflow 3.x -- consumers should read whichever key is
+present.
+
 **Response**:
 
 ```json

--- a/docs/api.md
+++ b/docs/api.md
@@ -273,8 +273,13 @@ Get DAG or pause/unpause a DAG
 | limit              | >=2.11  | int  | 50      |
 | offset             | >=2.11  | int  | 0       |
 | search             | >=2.11  | str  | example |
+| search_field       | >=2.11  | str  | dag_id  |
 
-When `limit`/`offset` are omitted, all DAGs are returned. `search` matches (case-insensitive substring) against `dag_id`, `owners`, and any DAG tag.
+When `limit`/`offset` are omitted, all DAGs are returned. `search` matches
+(case-insensitive substring) against `dag_id`, `owners`, and any DAG tag by
+default. Set `search_field` to `dag_id`, `owner`, or `tag` to restrict the
+match to that single column; any other value (or unset) preserves the default
+"any of the three" behaviour.
 
 **Response**:
 

--- a/tests/af3_compatability_dispatch_test.py
+++ b/tests/af3_compatability_dispatch_test.py
@@ -216,7 +216,7 @@ def test_compatability_layer_defaults_to_installed_airflow_version(monkeypatch):
     assert isinstance(StarshipCompatabilityLayer(), StarshipAirflow33)
 
 
-DAG_PAGINATION_PARAMS = ("limit", "offset", "search")
+DAG_PAGINATION_PARAMS = ("limit", "offset", "search", "search_field")
 
 DAG_ROW_KEYS = (
     "dag_id",

--- a/tests/af3_compatability_dispatch_test.py
+++ b/tests/af3_compatability_dispatch_test.py
@@ -21,6 +21,7 @@ ATTR_METHODS = [
     "pool_attrs",
     "variable_attrs",
     "connection_attrs",
+    "dag_attrs",
     "dag_run_attrs",
     "task_instance_attrs",
     "dag_runs_attrs",
@@ -213,3 +214,46 @@ def test_compatability_layer_defaults_to_installed_airflow_version(monkeypatch):
 
     monkeypatch.setattr(airflow, "__version__", "3.3.1", raising=False)
     assert isinstance(StarshipCompatabilityLayer(), StarshipAirflow33)
+
+
+DAG_PAGINATION_PARAMS = ("limit", "offset", "search")
+
+DAG_ROW_KEYS = (
+    "dag_id",
+    "timetable_summary",
+    "is_paused",
+    "fileloc",
+    "description",
+    "owners",
+    "tags",
+    "dag_run_count",
+)
+
+
+@pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
+@pytest.mark.parametrize("param", DAG_PAGINATION_PARAMS)
+def test_dag_attrs_pagination_params_are_get_only(cls, param):
+    # Params are consumed as query args by get_kwargs_fn and must not surface as row fields.
+    desc = cls.dag_attrs()[param]
+    assert desc["methods"] == [("GET", False)], desc
+
+
+@pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
+@pytest.mark.parametrize("row_key", DAG_ROW_KEYS)
+def test_dag_attrs_row_shape_regression(cls, row_key):
+    # Guards against accidentally dropping any existing dag_attrs row field when
+    # adding new params or subclass overrides.
+    assert row_key in cls.dag_attrs(), f"{cls.__name__}.dag_attrs missing row field {row_key!r}"
+
+
+@pytest.mark.parametrize("cls", ALL_AF3_SUBCLASSES)
+def test_dag_attrs_pagination_params_are_not_row_fields(cls):
+    # get_dags() must skip GET-only descriptors when building each row so the
+    # response doesn't contain phantom `limit`/`offset`/`search` keys.
+    row_attrs = {
+        attr: desc
+        for attr, desc in cls.dag_attrs().items()
+        if not (desc["methods"] and all(m[0] == "GET" for m in desc["methods"]))
+    }
+    for param in DAG_PAGINATION_PARAMS:
+        assert param not in row_attrs, f"{cls.__name__}.dag_attrs: {param!r} leaked into row shape"

--- a/tests/af3_insert_sanitization_test.py
+++ b/tests/af3_insert_sanitization_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from astronomer_starship._af3.starship_compatability import (
+    StarshipAirflow30,
     StarshipAirflow31,
     StarshipAirflow32,
     StarshipAirflow33,
@@ -10,6 +11,8 @@ from astronomer_starship._af3.starship_compatability import (
 # parametrize FK-stripping tests over every subclass to guard against a future override
 # silently dropping the stripping logic.
 STARSHIP_SUBCLASSES = [StarshipAirflow31, StarshipAirflow32, StarshipAirflow33]
+
+ALL_STARSHIP_SUBCLASSES = [StarshipAirflow30, StarshipAirflow31, StarshipAirflow32, StarshipAirflow33]
 
 
 class FakeColumn:
@@ -70,6 +73,32 @@ class FakeSession:
 
     def rollback(self):
         raise AssertionError("rollback should not be called")
+
+
+class FakeQuery:
+    """Minimal fake for a SQLAlchemy query chain: ``filter``/``group_by`` are no-ops; iteration yields ``rows``."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def group_by(self, *args, **kwargs):
+        return self
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class FakeQuerySession:
+    """Minimal fake for the SQLAlchemy session: ``.query(*cols)`` returns a FakeQuery over the pre-canned rows."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self, *columns):
+        return FakeQuery(self._rows)
 
 
 @pytest.mark.parametrize("starship_cls", STARSHIP_SUBCLASSES)
@@ -176,3 +205,73 @@ def test_task_instance_direct_insert_strips_source_trigger_id(monkeypatch, stars
             "map_index": -1,
         }
     ]
+
+
+# ---------------------------------------------------------------------------
+# Batched DAG-metadata helpers on BaseStarshipAirflow
+#
+# _fetch_tags_by_dag_id and _fetch_dag_run_counts back get_dags. Testing them
+# in isolation localizes regressions without going through the full pagination
+# code path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_fetch_tags_empty_input_returns_empty_dict(starship_cls):
+    starship = starship_cls()
+    # Contract: empty input short-circuits without touching the session.
+    starship._session = None
+    assert starship._fetch_tags_by_dag_id([]) == {}
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_fetch_tags_groups_multiple_tags_per_dag(starship_cls):
+    starship = starship_cls()
+    starship._session = FakeQuerySession(
+        [
+            ("dag_a", "tag1"),
+            ("dag_a", "tag2"),
+            ("dag_b", "tag3"),
+        ]
+    )
+    assert starship._fetch_tags_by_dag_id(["dag_a", "dag_b"]) == {
+        "dag_a": ["tag1", "tag2"],
+        "dag_b": ["tag3"],
+    }
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_fetch_tags_missing_dag_absent_from_result(starship_cls):
+    # DAGs without any tags don't appear as empty lists -- callers use
+    # dict.get(dag_id, []) at the read site.
+    starship = starship_cls()
+    starship._session = FakeQuerySession([("dag_a", "only_tag")])
+    assert starship._fetch_tags_by_dag_id(["dag_a", "dag_b_no_tags"]) == {"dag_a": ["only_tag"]}
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_fetch_run_counts_empty_input_returns_empty_dict(starship_cls):
+    starship = starship_cls()
+    starship._session = None
+    assert starship._fetch_dag_run_counts([]) == {}
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_fetch_run_counts_populates_from_group_by(starship_cls):
+    starship = starship_cls()
+    starship._session = FakeQuerySession(
+        [
+            ("dag_a", 5),
+            ("dag_b", 2),
+        ]
+    )
+    assert starship._fetch_dag_run_counts(["dag_a", "dag_b"]) == {"dag_a": 5, "dag_b": 2}
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_fetch_run_counts_zero_fills_missing_dags(starship_cls):
+    # Contract: dag_ids requested but absent from the GROUP BY result still
+    # appear with count 0. Row builders rely on this to produce complete rows.
+    starship = starship_cls()
+    starship._session = FakeQuerySession([("dag_a", 3)])
+    assert starship._fetch_dag_run_counts(["dag_a", "dag_never_ran"]) == {"dag_a": 3, "dag_never_ran": 0}

--- a/tests/af3_insert_sanitization_test.py
+++ b/tests/af3_insert_sanitization_test.py
@@ -1,4 +1,5 @@
 import pytest
+import sqlalchemy as sa
 
 from astronomer_starship._af3.starship_compatability import (
     StarshipAirflow30,
@@ -76,7 +77,7 @@ class FakeSession:
 
 
 class FakeQuery:
-    """Minimal fake for a SQLAlchemy query chain: ``filter``/``group_by`` are no-ops; iteration yields ``rows``."""
+    """Minimal fake for a SQLAlchemy query chain: ``filter``/``group_by``/``distinct`` are no-ops; iteration yields ``rows``."""
 
     def __init__(self, rows):
         self._rows = rows
@@ -85,6 +86,9 @@ class FakeQuery:
         return self
 
     def group_by(self, *args, **kwargs):
+        return self
+
+    def distinct(self, *args, **kwargs):
         return self
 
     def __iter__(self):
@@ -99,6 +103,39 @@ class FakeQuerySession:
 
     def query(self, *columns):
         return FakeQuery(self._rows)
+
+
+class RecordingQuery:
+    """Fake target query for ``_search_dag_query``: records the clause passed to ``filter`` instead of applying it."""
+
+    def __init__(self):
+        self.filtered_with = None
+
+    def filter(self, clause):
+        self.filtered_with = clause
+        return self
+
+
+class SelectBackedQuery:
+    """Like ``FakeQuery``, but backed by a real Core ``select()`` so it's still
+    a valid ``in_(...)`` target -- ``FakeQuery``'s plain rows iterator isn't."""
+
+    def __init__(self, stmt):
+        self._stmt = stmt
+
+    def filter(self, *clauses):
+        return SelectBackedQuery(self._stmt.where(*clauses))
+
+    def distinct(self):
+        return SelectBackedQuery(self._stmt.distinct())
+
+    def __clause_element__(self):
+        return self._stmt
+
+
+class SelectBackedSession:
+    def query(self, *columns):
+        return SelectBackedQuery(sa.select(*columns))
 
 
 @pytest.mark.parametrize("starship_cls", STARSHIP_SUBCLASSES)
@@ -275,3 +312,79 @@ def test_fetch_run_counts_zero_fills_missing_dags(starship_cls):
     starship = starship_cls()
     starship._session = FakeQuerySession([("dag_a", 3)])
     assert starship._fetch_dag_run_counts(["dag_a", "dag_never_ran"]) == {"dag_a": 3, "dag_never_ran": 0}
+
+
+# ---------------------------------------------------------------------------
+# _search_dag_query on BaseStarshipAirflow (backs get_dags' search_field param)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_search_dag_query_no_search_returns_query_unchanged(starship_cls):
+    starship = starship_cls()
+    starship._session = None
+    query = RecordingQuery()
+    assert starship._search_dag_query(query, None, None) is query
+    assert query.filtered_with is None
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_search_dag_query_empty_string_search_returns_query_unchanged(starship_cls):
+    starship = starship_cls()
+    starship._session = None
+    query = RecordingQuery()
+    assert starship._search_dag_query(query, "", "dag_id") is query
+    assert query.filtered_with is None
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_search_dag_query_dag_id_field_filters_only_dag_id(starship_cls):
+    starship = starship_cls()
+    starship._session = SelectBackedSession()
+    query = RecordingQuery()
+    starship._search_dag_query(query, "foo", "dag_id")
+    clause = str(query.filtered_with)
+    assert "dag.dag_id" in clause
+    assert "dag.owners" not in clause
+    assert "dag_tag" not in clause
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_search_dag_query_owner_field_filters_only_owners(starship_cls):
+    starship = starship_cls()
+    starship._session = SelectBackedSession()
+    query = RecordingQuery()
+    starship._search_dag_query(query, "foo", "owner")
+    clause = str(query.filtered_with)
+    assert "dag.owners" in clause
+    assert "dag.dag_id" not in clause
+    assert "dag_tag" not in clause
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+def test_search_dag_query_tag_field_filters_via_tag_subquery(starship_cls):
+    starship = starship_cls()
+    starship._session = SelectBackedSession()
+    query = RecordingQuery()
+    starship._search_dag_query(query, "foo", "tag")
+    clause = str(query.filtered_with)
+    assert "dag.dag_id IN" in clause
+    assert "dag_tag" in clause
+    assert "LIKE" not in clause.split("IN")[0]
+    assert "dag.owners" not in clause
+
+
+@pytest.mark.parametrize("starship_cls", ALL_STARSHIP_SUBCLASSES)
+@pytest.mark.parametrize("search_field", [None, "", "bogus"])
+def test_search_dag_query_unset_or_unknown_field_matches_all_columns(starship_cls, search_field):
+    # Regression coverage for 3a49e05 (SQLAlchemy clauses raise on __bool__,
+    # so this can't be a truthy check on field_filters.get(...)).
+    starship = starship_cls()
+    starship._session = SelectBackedSession()
+    query = RecordingQuery()
+    starship._search_dag_query(query, "foo", search_field)
+    clause = str(query.filtered_with)
+    assert "dag.dag_id" in clause
+    assert "dag.owners" in clause
+    assert "dag_tag" in clause
+    assert clause.count(" OR ") == 2

--- a/tests/api_integration_test.py
+++ b/tests/api_integration_test.py
@@ -114,7 +114,9 @@ def test_integration_dags(url_and_token_and_starship):
     for dag in dags:
         if dag["dag_id"] == expected_get["dag_id"]:
             assert dag["dag_id"] == expected_get["dag_id"], actual.text
-            assert dag["schedule_interval"] == expected_get["schedule_interval"], actual.text
+            # `schedule_interval` on AF2, `timetable_summary` on AF3 -- read whichever the fixture supplies.
+            schedule_key = "schedule_interval" if "schedule_interval" in expected_get else "timetable_summary"
+            assert dag[schedule_key] == expected_get[schedule_key], actual.text
             assert dag["is_paused"] == expected_get["is_paused"], actual.text
             assert dag["description"] == expected_get["description"], actual.text
             assert dag["owners"] == expected_get["owners"], actual.text

--- a/tests/api_integration_test.py
+++ b/tests/api_integration_test.py
@@ -107,7 +107,11 @@ def test_integration_dags(url_and_token_and_starship):
     expected_get = get_test_data(attrs=starship.dag_attrs())
     actual = requests.get(f"{url}/{route}", **get_extras(url, token))
     assert actual.status_code == 200, actual.text
-    for dag in actual.json():
+    body = actual.json()
+    # get_dags returns {"dags": [...], "total_dag_count": N} (>=2.11);
+    # older releases returned a bare list.
+    dags = body["dags"] if isinstance(body, dict) else body
+    for dag in dags:
         if dag["dag_id"] == expected_get["dag_id"]:
             assert dag["dag_id"] == expected_get["dag_id"], actual.text
             assert dag["schedule_interval"] == expected_get["schedule_interval"], actual.text

--- a/tests/docker_test/docker_test.py
+++ b/tests/docker_test/docker_test.py
@@ -100,19 +100,54 @@ def test_dags(starship):
     assert actual == test_input, actual
 
     test_input = get_test_data(attrs=starship.dag_attrs())
-    actual = starship.get_dags()
+    result = starship.get_dags()
+    # get_dags returns {"dags": [...], "total_dag_count": N} (>=2.11);
+    # older releases returned a bare list.
+    actual = result["dags"] if isinstance(result, dict) else result
     actual_dags = [dag for dag in actual if dag["dag_id"] == test_input["dag_id"]]
     assert len(actual_dags) == 1, actual_dags
 
     # not predictable, so remove it
     del actual_dags[0]["fileloc"]
-    del test_input["fileloc"]
 
     # not predictable (sorting), so remove it
     del actual_dags[0]["tags"]
-    del test_input["tags"]
 
-    assert actual_dags[0] == test_input, actual_dags[0]
+    # Row-shape assertion should ignore keys that only appear in test_input as
+    # query-param descriptors (limit/offset/search), which are never row fields.
+    filtered_input = {k: v for k, v in test_input.items() if k in actual_dags[0]}
+    assert actual_dags[0] == filtered_input, actual_dags[0]
+
+
+@docker_test
+def test_dags_pagination_and_search(starship):
+    # Response wraps the list plus a total that reflects the filter, not the page window.
+    result = starship.get_dags()
+    assert isinstance(result, dict), result
+    assert "dags" in result and "total_dag_count" in result, result
+    all_dags = result["dags"]
+    total = result["total_dag_count"]
+    assert total == len(all_dags), (total, len(all_dags))
+
+    # Paged fetch returns a slice of the same set.
+    if total >= 2:
+        page = starship.get_dags(limit=1, offset=0)
+        assert len(page["dags"]) == 1, page
+        assert page["total_dag_count"] == total, page
+
+        next_page = starship.get_dags(limit=1, offset=1)
+        assert len(next_page["dags"]) == 1, next_page
+        assert next_page["dags"][0]["dag_id"] != page["dags"][0]["dag_id"], (page, next_page)
+
+    # Search restricts total_dag_count, not just the page window.
+    if all_dags:
+        target = all_dags[0]["dag_id"]
+        hit = starship.get_dags(search=target)
+        assert hit["total_dag_count"] >= 1, hit
+        assert any(d["dag_id"] == target for d in hit["dags"]), hit
+
+    miss = starship.get_dags(search="__nonexistent_starship_test_dag__")
+    assert miss == {"dags": [], "total_dag_count": 0}, miss
 
 
 @docker_test

--- a/tests/docker_test/docker_test.py
+++ b/tests/docker_test/docker_test.py
@@ -151,6 +151,46 @@ def test_dags_pagination_and_search(starship):
 
 
 @docker_test
+def test_dags_search_field(starship):
+    # search_field=None|""|"bogus" must fall back to OR-across-all (regression:
+    # `field_filters.get(x) or or_(...)` used to raise TypeError on the returned
+    # SQLAlchemy clause via __bool__).
+    result = starship.get_dags()
+    all_dags = result["dags"]
+    if not all_dags:
+        return  # No DAGs to filter against; test is a no-op.
+
+    sample = all_dags[0]
+    dag_id = sample["dag_id"]
+
+    # search_field=dag_id: matches the sample DAG by its id.
+    by_id = starship.get_dags(search=dag_id, search_field="dag_id")
+    assert by_id["total_dag_count"] >= 1, by_id
+    assert any(d["dag_id"] == dag_id for d in by_id["dags"]), by_id
+
+    # search_field=owner: substring-match on owners.
+    if sample.get("owners"):
+        owner_frag = sample["owners"].split(",")[0].strip()
+        if owner_frag:
+            by_owner = starship.get_dags(search=owner_frag, search_field="owner")
+            assert by_owner["total_dag_count"] >= 1, by_owner
+
+    # search_field=tag: substring-match on any tag.
+    if sample.get("tags"):
+        tag_frag = sample["tags"][0]
+        by_tag = starship.get_dags(search=tag_frag, search_field="tag")
+        assert by_tag["total_dag_count"] >= 1, by_tag
+        assert any(dag_id == d["dag_id"] for d in by_tag["dags"]), by_tag
+
+    # Unknown search_field values must not error; they degrade to the
+    # OR-across-all behaviour of an unset field.
+    any_any = starship.get_dags(search=dag_id)
+    for field in ("", "bogus", "any"):
+        alt = starship.get_dags(search=dag_id, search_field=field)
+        assert alt["total_dag_count"] == any_any["total_dag_count"], (field, alt, any_any)
+
+
+@docker_test
 def test_dag_runs_and_task_instances(starship):
     test_input = get_test_data(method="POST", attrs=starship.dag_runs_attrs())
     dag_id = test_input["dag_runs"][0]["dag_id"]


### PR DESCRIPTION
🤖 This PR was drafted with assistance from Claude Opus 4.7

Closes #178 

## Summary
The DAG History tab was loading every DAG in the deployment on every render. Behind the scenes, get_dags executed an N+1 SELECT (one query per DAG for tags + one per DAG for run counts), then the frontend did client-side pagination and search on the result. Deployments with more than a few hundred DAGs became sluggish.

This PR ships server-side pagination, scoped search, an N+1 fix, a bulk-pause confirmation modal with live progress.

> ⚠️ Breaking API change: GET /api/starship/dags now returns {"dags": [...], "total_dag_count": N} instead of a bare list. Internal callers (frontend + operator) handle both shapes for graceful upgrade; external API users must update. Details in section 10.

## Features
#### 1. Server-side pagination
Fetches only the visible page from GET /dags?limit=…&offset=…. Rows-per-page selector (25 / 50 / 100 / 200), prev/next arrows, and a Showing 51–100 of 1007 row-range indicator. Page state persists in localStorage.
<img width="1283" height="142" alt="Screenshot 2026-09-05 at 12 54 16 PM" src="https://github.com/user-attachments/assets/bbca01e3-260a-406e-8ed1-3cc20fad5be1" />

#### 2. Server-side search
Search matches DAG ID, owner, or any tag (case-insensitive substring) by default.

#### 3. Search-field selector
Dropdown next to the search input: Any field / DAG ID / Owner / Tag.

#### 4. Bordered "Filter" widget with Reset button
Reset button appears when a filter is active, clears both field and value.
<img width="1279" height="389" alt="Screenshot 2026-09-05 at 12 54 59 PM" src="https://github.com/user-attachments/assets/3cbf19da-3e05-40ad-b4af-2414ed4a4db8" />
<img width="1287" height="128" alt="Screenshot 2026-09-05 at 12 55 11 PM" src="https://github.com/user-attachments/assets/31e4098b-06e7-4e76-8104-2f420bd4d683" />

#### 5. Confirmation modal for Pause All / Unpause All
Both buttons (Local and Remote) now open a Chakra AlertDialog showing the exact count of DAGs the action will affect and any active search filter. Prevents accidental bulk operations.

#### 6. Bulk operations act on all matching DAGs
Under the hood, Pause All / Unpause All now fetch every DAG matching the current search rather than only what's on screen.
<img width="1278" height="443" alt="Screenshot 2026-09-05 at 12 56 37 PM" src="https://github.com/user-attachments/assets/a86d9bc5-6881-4ee9-a4e4-fe0a36888031" />
<img width="1274" height="448" alt="Screenshot 2026-09-05 at 12 56 47 PM" src="https://github.com/user-attachments/assets/ed6dae66-0d42-4a91-ad5e-057b1578441a" />

#### 7. Live progress inside the bulk-pause modal
Modal stays open through the operation. Live-updating counter: with a striped, animated progress bar. ESC / overlay-click are disabled while running so the loop can't be orphaned.

#### 8. Stop button (abort mid-operation)
Cancel button transitions to a red Stop button while the loop is running.
<img width="1276" height="562" alt="Screenshot 2026-09-05 at 12 57 35 PM" src="https://github.com/user-attachments/assets/4aa81239-21fe-4cd0-944e-10b4f0e3055e" />

#### 9. N+1 query fix in get_dags
Was one SELECT per DAG for tags + one per DAG for run counts (2N + 2 queries). Now 4 queries per page regardless of DAG count: count, page, batched tag lookup, batched run-count group-by. On a 1007-DAG load test, every page rendered in under 100 ms.

#### 10. New GET /api/starship/dags contract
- Optional query params: limit, offset, search, search_field.
- Breaking: response is now wrapped: { "dags": [...], "total_dag_count": N }. Previously it returned a bare list [...]. total_dag_count reflects the search filter, not the page window.
- Starship's own internal callers were updated to accept both shapes so mixed-version source/target deployments keep working:
  - Frontend DAGHistoryPage unwraps res.data.dags or falls back to res.data if it's an array.
  - StarshipAirflowMigrationDAG factory in providers/starship/operators/starship.py does the same.
- External API consumers must update their parsing — anyone calling /api/starship/dags from custom scripts or third-party integrations will need to read .dags instead of iterating the top-level response.
- Documented in api.md.

#### 11. CI: prettier hook fix
Pin prettier to 3.4.2 and mark hook require_serial: true in .pre-commit-config.yaml. Eliminates the recurring SyntaxError: Unexpected end of input on random .jsx files that was hitting main-branch CI - a race between parallel npx batches sharing the npm cache dir.

#### Testing:
**Astro deployments:**
- Astro Runtime 3.3-6 (Airflow 3.3.1)
- Astro Runtime 13.10.0 (Airflow 2.11.2)
- **Load test:** 1007 DAGs - every paged filter query returned sub-100 ms.