### PR TITLE
Resolve failing gh-action-pip-audit version

### DIFF
--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -23,7 +23,7 @@ jobs:
         run: pip install -c constraints.txt '.[dev]'
 
       - name: Run pip-audit
-        uses: pypa/gh-action-pip-audit@v1
+        uses: pypa/gh-action-pip-audit@v1.1.0
 
   audit-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This resolves the permanently failing audit-python step in the [Security Audit pipeline](https://github.com/astronomer/starship/actions/workflows/security-audit.yaml) due to an invalid version, by configuring a valid version.