### PR TITLE
Bump several action versions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,9 +24,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
       - run: just install
       - run: just test-with-coverage
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -12,9 +12,9 @@ jobs:
   audit-python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -28,9 +28,9 @@ jobs:
   audit-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
This resolves several deprecation warnings in the CICD. See e.g. annotations in https://github.com/astronomer/starship/actions/runs/34107509146.